### PR TITLE
Compute live flight metrics for status panel

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSimStore } from "@/components/useSimStore";
 import MapCanvas from "@/components/MapCanvas";
@@ -11,10 +11,69 @@ import Header from "@/components/Header";
 import StateResetOnPageLoad from "@/components/StateResetOnPageLoad";
 import ViewOptionsControl from "@/components/ViewOptionsControl";
 
+function countTimesUpTo(sortedTimes: number[], value: number): number {
+  let lo = 0;
+  let hi = sortedTimes.length;
+
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (sortedTimes[mid] <= value) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  return lo;
+}
+
 export default function Page() {
   const router = useRouter();
   const user = useSimStore((state) => state.user);
+  const flights = useSimStore((state) => state.flights);
+  const t = useSimStore((state) => state.t);
   const [hydrated, setHydrated] = useState(false);
+
+  const sortedStartTimes = useMemo(() => {
+    if (!flights || flights.length === 0) {
+      return [] as number[];
+    }
+
+    return flights
+      .map((flight) => flight.t0)
+      .filter((time) => Number.isFinite(time))
+      .sort((a, b) => a - b);
+  }, [flights]);
+
+  const sortedEndTimes = useMemo(() => {
+    if (!flights || flights.length === 0) {
+      return [] as number[];
+    }
+
+    return flights
+      .map((flight) => flight.t1)
+      .filter((time) => Number.isFinite(time))
+      .sort((a, b) => a - b);
+  }, [flights]);
+
+  const { total: flightsTotal, landed: flightsLanded, airborne: flightsAirborne } = useMemo(() => {
+    const total = flights?.length ?? 0;
+    if (total === 0) {
+      return { total: 0, landed: 0, airborne: 0 };
+    }
+
+    const startedCount = Math.min(total, countTimesUpTo(sortedStartTimes, t));
+    const landedCount = Math.min(total, countTimesUpTo(sortedEndTimes, t));
+    const inFlight = startedCount - landedCount;
+    const remaining = Math.max(0, total - landedCount);
+    const airborneCount = Math.max(0, Math.min(inFlight, remaining));
+
+    return {
+      total,
+      landed: landedCount,
+      airborne: airborneCount,
+    };
+  }, [flights, sortedStartTimes, sortedEndTimes, t]);
 
   useEffect(() => {
     const unsub = useSimStore.persist.onFinishHydration(() => setHydrated(true));
@@ -42,7 +101,12 @@ export default function Page() {
       {/* Left-side wrapper: full-height, scrolls; panel inside does not */}
       <div className="absolute top-0 left-4 z-40 w-[360px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4">
         <LeftControl1 embedded />
-        <NetworkStatusPanel embedded />
+        <NetworkStatusPanel
+          embedded
+          flightsTotal={flightsTotal}
+          flightsLanded={flightsLanded}
+          flightsAirborne={flightsAirborne}
+        />
       </div>
       {/* Right-side wrapper: full-height scroll for the panel */}
       <div className="absolute top-0 right-4 z-40 w-[384px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">

--- a/src/components/NetworkStatusPanel.tsx
+++ b/src/components/NetworkStatusPanel.tsx
@@ -57,15 +57,19 @@ const DEFAULT_HISTOGRAM: HistogramBin[] = [
 
 export default function NetworkStatusPanel({
   embedded = true,
-  flightsTotal = 1042,
-  flightsLanded = 612,
-  flightsAirborne = 430,
+  flightsTotal = 0,
+  flightsLanded = 0,
+  flightsAirborne = 0,
   averageDelayMinutes = 14,
   delayCauses = DEFAULT_DELAY_CAUSES,
   delayHistogram = DEFAULT_HISTOGRAM,
 }: NetworkStatusPanelProps) {
   // Local state for the expandable causes table
   const [showAllCauses, setShowAllCauses] = useState(false);
+
+  const flightsTotalDisplay = useMemo(() => formatFlightCount(flightsTotal), [flightsTotal]);
+  const flightsLandedDisplay = useMemo(() => formatFlightCount(flightsLanded), [flightsLanded]);
+  const flightsAirborneDisplay = useMemo(() => formatFlightCount(flightsAirborne), [flightsAirborne]);
 
   // Sort causes by count desc for table and pie accumulation
   const sortedCauses = useMemo(() => {
@@ -128,9 +132,9 @@ export default function NetworkStatusPanel({
         <div className="bg-white/5 rounded-lg p-4">
           <h2 className="font-semibold mb-3">Flights</h2>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-            <MetricCard label="Total" value={flightsTotal.toLocaleString()} />
-            <MetricCard label="Landed" value={flightsLanded.toLocaleString()} />
-            <MetricCard label="Airborne" value={flightsAirborne.toLocaleString()} />
+            <MetricCard label="Total" value={flightsTotalDisplay} />
+            <MetricCard label="Landed" value={flightsLandedDisplay} />
+            <MetricCard label="Airborne" value={flightsAirborneDisplay} />
           </div>
         </div>
 
@@ -227,4 +231,26 @@ function MetricCard({ label, value, accent }: { label: string; value: string | n
       <div className="text-xl font-semibold leading-tight">{value}</div>
     </div>
   );
+}
+
+const compactNumberFormatter = new Intl.NumberFormat("en", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+function formatFlightCount(value?: number): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "0";
+  }
+
+  const safeValue = Math.max(0, Math.round(value));
+  if (safeValue === 0) {
+    return "0";
+  }
+
+  if (safeValue >= 1000) {
+    return compactNumberFormatter.format(safeValue).toLowerCase();
+  }
+
+  return safeValue.toLocaleString();
 }


### PR DESCRIPTION
## Summary
- derive the total, landed, and airborne flight counts from the simulation store in the main page
- pass the live counts to the network status panel and format them with a compact flight-count helper

## Testing
- npm run lint *(fails: existing lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a0629d54832bb3a5c9f42a7948e0