### PR TITLE
Add shared weather overlay handling to canvases

### DIFF
--- a/src/app/flow-evaluation/page.tsx
+++ b/src/app/flow-evaluation/page.tsx
@@ -1639,14 +1639,14 @@ function FlowsSummary({ flows, colors, optDelays }: { flows: Record<string, stri
         const shown = showAll ? list : list.slice(0, 25);
         const color = colors?.[String(fid)] || '#0f468a';
         return (
-          <div key={fid} className="text-sm text-white/90">
-            <div className="flex items-center justify-between mb-1">
+          <div key={fid} className="text-[12px] text-white/90">
+            <div className="flex items-center justify-between mb-2">
               <div className="flex items-center gap-2">
-                <span className="inline-block w-2 h-2 rounded-full" style={{ background: color }} />
-                <span>Flow {fid}</span>
+                <span className="inline-block w-3 h-3 rounded-sm" style={{ background: color }} />
+                <span className="font-medium text-sm opacity-90">Flow {fid}</span>
               </div>
-              <div className="flex items-center gap-2">
-                <span className="text-white/70">{list.length} flights</span>
+              <div className="flex items-center gap-2 text-[11px] text-white/70">
+                <span>{list.length} flights</span>
                 {list.length > 25 && (
                   <button onClick={() => toggle(fid)} className="px-1.5 py-0.5 rounded bg-white/10 border border-white/20 text-[11px] text-white/80 hover:bg-white/15">
                     {showAll ? 'Show less' : 'Show all'}
@@ -1655,16 +1655,16 @@ function FlowsSummary({ flows, colors, optDelays }: { flows: Record<string, stri
               </div>
             </div>
             {list.length > 0 ? (
-              <div className="rounded-lg border border-white/10 bg-white/5 overflow-hidden">
-                <div className="overflow-visible">
-                  <table className="w-full text-xs min-w-max whitespace-nowrap">
-                    <thead className="sticky top-0 z-10 bg-blue-900">
-                      <tr className="text-white">
+              <div className="rounded-lg border border-white/10 overflow-hidden">
+                <div className="overflow-x-auto">
+                  <table className="min-w-full text-[11px]">
+                    <thead>
+                      <tr className="bg-white/10 text-white/80">
                         <th className="text-left p-2 font-semibold">Callsign</th>
                         <th className="text-left p-2 font-semibold">Origin</th>
                         <th className="text-left p-2 font-semibold">Destination</th>
-                        <th className="text-left p-2 font-semibold">Takeoff</th>
-                        <th className="text-left p-2 font-semibold">Delay (min)</th>
+                        <th className="text-right p-2 font-semibold">Takeoff</th>
+                        <th className="text-right p-2 font-semibold">Delay (min)</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -1681,12 +1681,15 @@ function FlowsSummary({ flows, colors, optDelays }: { flows: Record<string, stri
                           return Number.isFinite(v) ? Number(v) : null;
                         })();
                         return (
-                          <tr key={`${fid}-${i}`} className={`border-b border-white/10 ${i % 2 === 0 ? 'bg-white/2' : ''}`}>
+                          <tr
+                            key={`${fid}-${i}`}
+                            className={`border-t border-white/10 ${i % 2 === 0 ? 'bg-white/0' : 'bg-white/5'} hover:bg-white/10`}
+                          >
                             <td className="p-2 font-mono">{callsign}</td>
                             <td className="p-2">{origin}</td>
                             <td className="p-2">{destination}</td>
-                            <td className="p-2 font-mono">{takeoff}</td>
-                            <td className="p-2 font-mono">{delayVal === null ? '—' : delayVal}</td>
+                            <td className="p-2 text-right font-mono">{takeoff}</td>
+                            <td className="p-2 text-right font-mono">{delayVal === null ? '—' : delayVal}</td>
                           </tr>
                         );
                       })}

--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -6,15 +6,15 @@ import { loadTrajectories } from "@/lib/flights";
 import { loadSectors } from "@/lib/airspace";
 import * as turf from "@turf/turf";
 import { useSimStore } from "@/components/useSimStore";
-import { Trajectory } from "@/lib/models";
 import PageLoadingIndicator from "@/components/PageLoadingIndicator";
+import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
 
 export default function FlowCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
   const rafRef = useRef<number | undefined>(undefined);
   const lastTs = useRef<number>(performance.now());
   const lastUpdateRef = useRef<number>(performance.now());
-  const { t, tick, setRange, showFlightLineLabels, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, flowViewEnabled, flowCommunities, flowGroups, flowPreviewGroupId, flowPreviewFlightId, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
+  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, flowViewEnabled, flowCommunities, flowGroups, flowPreviewGroupId, flowPreviewFlightId, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
   
   const [highlightedTrafficVolume, setHighlightedTrafficVolume] = useState<string | null>(null);
   const [hoveredTrafficVolume, setHoveredTrafficVolume] = useState<string | null>(null);
@@ -308,6 +308,45 @@ export default function FlowCanvas() {
 
   // Ensure filters also react to flow mapping toggles (e.g., Flow Basket eye button)
   useEffect(() => { updateFlightLineFilters(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups]);
+
+  // Weather overlay integration (Surface Precipitation)
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (weatherOverlay !== "surface-precip") {
+      hideSurfacePrecipLayer(map);
+      return;
+    }
+
+    const targetHour = isoHourFrom(date, t);
+
+    const apply = () => {
+      try {
+        ensureSurfacePrecipHour(map, targetHour);
+      } catch (e) {
+        // no-op
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      apply();
+      return;
+    }
+
+    let cancelled = false;
+    const waitForReady = () => {
+      if (!map.isStyleLoaded()) return;
+      try { map.off("render", waitForReady); } catch {}
+      if (!cancelled) apply();
+    };
+
+    map.on("render", waitForReady);
+    return () => {
+      cancelled = true;
+      try { map.off("render", waitForReady); } catch {}
+    };
+  }, [weatherOverlay, t, date]);
 
   // on showFlightLineLabels change, toggle visibility
   useEffect(() => {

--- a/src/components/FlowPlanPanel.tsx
+++ b/src/components/FlowPlanPanel.tsx
@@ -444,67 +444,71 @@ export default function FlowPlanPanel({ embedded = false }: FlowPlanPanelProps) 
                         />
                       </div>
                       <div className="px-2 pb-2">
-                        <table className="w-full text-[11px]">
-                          <thead>
-                            <tr className="bg-blue-900 text-white">
-                              <th className="text-left p-2 font-semibold">CS</th>
-                              <th className="text-left p-2 font-semibold">Ori.</th>
-                              <th className="text-left p-2 font-semibold">Des.</th>
-                              <th className="text-left p-2 font-semibold">Requested Bin</th>
-                              <th className="text-left p-2 font-semibold">Earliest Crossing</th>
-                              <th className="text-left p-2 font-semibold">Actions</th>
-                            </tr>
-                          </thead>
-                          <tbody>
-                            {(bf.items || []).map((it) => {
-                              const key = it.key;
-                              const f = resolveByKey(key);
-                              const callsign = f?.callSign || key;
-                              const origin = f?.origin || '—';
-                              const destination = f?.destination || '—';
-                              return (
-                                <tr
-                                  key={`${bf.id}-${key}`}
-                                  className="border-b border-white/10 hover:bg-white/10"
-                                  onMouseEnter={() => { if (f?.flightId) setFlowPreviewFlightId(String(f.flightId)); }}
-                                  onMouseLeave={() => setFlowPreviewFlightId(null)}
-                                >
-                                  <td className="p-2 font-mono">{callsign}</td>
-                                  <td className="p-2">{origin}</td>
-                                  <td className="p-2">{destination}</td>
-                                  <td className="p-2">{it.requestedBin != null ? String(it.requestedBin) : '—'}</td>
-                                  <td className="p-2">{it.earliestCrossing != null ? String(it.earliestCrossing) : '—'}</td>
-                                  <td className="p-2">
-                                    <div className="flex items-center gap-2">
-                                      {/* Move */}
-                                      <MoveFlightMenu
-                                        flows={flowBasket}
-                                        currentFlowId={bf.id}
-                                        onMove={(toId) => moveFlightBetweenBasketFlows(bf.id, toId, key)}
-                                      />
-                                      {/* Delete */}
-                                      <button
-                                        className="p-1 text-white/70 hover:text-red-200"
-                                        title="Remove from this flow"
-                                        onClick={() => removeFlightFromBasketFlow(bf.id, key)}
-                                      >
-                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6h18M8 6v12m8-12v12M5 6l1 14h12l1-14M9 3h6l1 3H8l1-3z" stroke="currentColor" strokeWidth="1.5"/></svg>
-                                      </button>
-                                    </div>
-                                  </td>
+                        <div className="rounded-lg border border-white/10 overflow-hidden">
+                          <div className="overflow-x-auto">
+                            <table className="min-w-full text-[11px]">
+                              <thead>
+                                <tr className="bg-white/10">
+                                  <th className="text-left p-2 font-semibold">CS</th>
+                                  <th className="text-left p-2 font-semibold">Ori.</th>
+                                  <th className="text-left p-2 font-semibold">Des.</th>
+                                  <th className="text-left p-2 font-semibold">Requested Bin</th>
+                                  <th className="text-left p-2 font-semibold">Earliest Crossing</th>
+                                  <th className="text-right p-2 font-semibold">Actions</th>
                                 </tr>
-                              );
-                            })}
-                            {/* New row */}
-                            <NewFlightRow
-                              onAdd={(token) => {
-                                const trimmed = String(token || '').trim();
-                                if (!trimmed) return;
-                                addFlightsToBasketFlow(bf.id, [trimmed]);
-                              }}
-                            />
-                          </tbody>
-                        </table>
+                              </thead>
+                              <tbody>
+                                {(bf.items || []).map((it, idx) => {
+                                  const key = it.key;
+                                  const f = resolveByKey(key);
+                                  const callsign = f?.callSign || key;
+                                  const origin = f?.origin || '—';
+                                  const destination = f?.destination || '—';
+                                  return (
+                                    <tr
+                                      key={`${bf.id}-${key}`}
+                                      className={`border-t border-white/10 ${idx % 2 === 0 ? 'bg-white/0' : 'bg-white/5'} hover:bg-white/10`}
+                                      onMouseEnter={() => { if (f?.flightId) setFlowPreviewFlightId(String(f.flightId)); }}
+                                      onMouseLeave={() => setFlowPreviewFlightId(null)}
+                                    >
+                                      <td className="p-2 font-mono">{callsign}</td>
+                                      <td className="p-2">{origin}</td>
+                                      <td className="p-2">{destination}</td>
+                                      <td className="p-2 text-right font-mono">{it.requestedBin != null ? String(it.requestedBin) : '—'}</td>
+                                      <td className="p-2 text-right font-mono">{it.earliestCrossing != null ? String(it.earliestCrossing) : '—'}</td>
+                                      <td className="p-2">
+                                        <div className="flex items-center justify-end gap-2">
+                                          {/* Move */}
+                                          <MoveFlightMenu
+                                            flows={flowBasket}
+                                            currentFlowId={bf.id}
+                                            onMove={(toId) => moveFlightBetweenBasketFlows(bf.id, toId, key)}
+                                          />
+                                          {/* Delete */}
+                                          <button
+                                            className="p-1 text-white/70 hover:text-red-200"
+                                            title="Remove from this flow"
+                                            onClick={() => removeFlightFromBasketFlow(bf.id, key)}
+                                          >
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6h18M8 6v12m8-12v12M5 6l1 14h12l1-14M9 3h6l1 3H8l1-3z" stroke="currentColor" strokeWidth="1.5"/></svg>
+                                          </button>
+                                        </div>
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                                {/* New row */}
+                                <NewFlightRow
+                                  onAdd={(token) => {
+                                    const trimmed = String(token || '').trim();
+                                    if (!trimmed) return;
+                                    addFlightsToBasketFlow(bf.id, [trimmed]);
+                                  }}
+                                />
+                              </tbody>
+                            </table>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   );
@@ -599,8 +603,8 @@ function isValidTimeRange(from: string, to: string): boolean {
 function NewFlightRow({ onAdd }: { onAdd: (token: string) => void }) {
   const [value, setValue] = useState("");
   return (
-    <tr className="bg-white/5">
-      <td className="p-2" colSpan={4}>
+    <tr className="border-t border-white/10 bg-white/5">
+      <td className="p-2" colSpan={5}>
         <input
           value={value}
           onChange={(e) => setValue(e.currentTarget.value)}
@@ -608,7 +612,6 @@ function NewFlightRow({ onAdd }: { onAdd: (token: string) => void }) {
           className="w-full px-2 py-1 bg-white/10 border border-white/20 rounded-md text-white text-[11px] focus:outline-none"
         />
       </td>
-      <td className="p-2 text-right" colSpan={1}></td>
       <td className="p-2 text-right">
         <button
           onClick={() => { const v = value.trim(); if (!v) return; onAdd(v); setValue(""); }}

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -10,6 +10,7 @@ import { useSimStore } from "@/components/useSimStore";
 import { Trajectory } from "@/lib/models";
 import FlightDetailsPopup from "@/components/FlightDetailsPopup";
 import PageLoadingIndicator from "@/components/PageLoadingIndicator";
+import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
 
 export default function MapCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
@@ -552,8 +553,7 @@ export default function MapCanvas() {
 
     // If overlay is disabled, hide any existing precip layers
     if (weatherOverlay !== 'surface-precip') {
-      hideTpLayers(map);
-      (map as any).__tpCurrentId = undefined;
+      hideSurfacePrecipLayer(map);
       return;
     }
 
@@ -561,7 +561,7 @@ export default function MapCanvas() {
 
     const apply = () => {
       try {
-        ensureTpHour(map, targetHour);
+        ensureSurfacePrecipHour(map, targetHour);
       } catch (e) {
         // no-op
       }
@@ -1015,89 +1015,3 @@ function updatePlanePositions(map: maplibregl.Map | null) {
   }
 }
 
-// --- Weather overlay helpers ---
-function isoHourFrom(dateStr: string, t: number): string {
-  // dateStr is DD/MM/YYYY
-  const [ddStr, mmStr, yyyyStr] = String(dateStr || '').split('/') as [string, string, string];
-  const dd = Number(ddStr || '1');
-  const mm = Number(mmStr || '1');
-  const yyyy = Number(yyyyStr || '1970');
-  const hour = Math.max(0, Math.min(23, Math.floor((t || 0) / 3600)));
-  const y = String(yyyy).padStart(4, '0');
-  const m = String(mm).padStart(2, '0');
-  const d = String(dd).padStart(2, '0');
-  const h = String(hour).padStart(2, '0');
-  return `${y}-${m}-${d}T${h}`;
-}
-
-function tpTile(urlEncodedCog: string): string {
-  const titiler = "http://localhost:8001";
-  return `${titiler}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?url=${urlEncodedCog}`;
-}
-
-function ensureTpHour(map: maplibregl.Map, isoHour: string) {
-  if (!map || !map.isStyleLoaded()) return;
-  const id = 'era5_tp';
-  const prevHour: string | undefined = (map as any).__tpHour;
-  if (prevHour === isoHour && map.getLayer(id)) {
-    // Already showing this hour
-    try { map.setPaintProperty(id, 'raster-opacity', 0.65); } catch {}
-    return;
-  }
-
-  const cog = encodeURIComponent(`https://wxtiles.tailwind-api.intuelle.com/cogs/era5_tp_${isoHour}.tif`);
-  const tiles = [rasterTile(cog, { rescale: [0, 5], colormap_name: 'viridis', resampling_method: 'bilinear' })];
-
-  // If a previous source/layer exists, remove to force refetch with new tiles
-  if (map.getLayer(id)) {
-    try { map.removeLayer(id); } catch {}
-  }
-  if (map.getSource(id)) {
-    try { map.removeSource(id); } catch {}
-  }
-
-  map.addSource(id, {
-    type: 'raster',
-    tiles,
-    tileSize: 256,
-    attribution: 'ECMWF/Copernicus'
-  } as any);
-
-  // Insert below airspace/traffic volume layers so they stay above weather (fallback to flight lines)
-  const layerOrderPreference = [
-    'sector-fill',
-    'sector-outline',
-    'sector-labels',
-    'sector-highlight',
-    'sector-highlight-outline',
-    'sector-hover',
-    'sector-hover-outline',
-    'sector-hotspot',
-    'sector-hotspot-outline',
-    'flight-lines'
-  ];
-  const beforeId = layerOrderPreference.find((layerId) => map.getLayer(layerId));
-  const layer: any = { id, type: 'raster', source: id, paint: { 'raster-opacity': 0.65 } };
-  // @ts-ignore second param optional
-  map.addLayer(layer, beforeId);
-
-  (map as any).__tpHour = isoHour;
-}
-
-function hideTpLayers(map: maplibregl.Map) {
-  if (!map || !map.isStyleLoaded()) return;
-  try {
-    const id = 'era5_tp';
-    if (map.getLayer(id)) map.setPaintProperty(id, 'raster-opacity', 0);
-  } catch {}
-}
-
-function rasterTile(urlEncodedCog: string, params?: { rescale?: [number, number]; colormap_name?: string; resampling_method?: string; nodata?: number }): string {
-  const titiler = "https://wxtiles.tailwind-api.intuelle.com";
-  const qp: string[] = [`url=${urlEncodedCog}`];
-  if (params?.rescale) qp.push(`rescale=${params.rescale[0]},${params.rescale[1]}`);
-  if (params?.colormap_name) qp.push(`colormap_name=${params.colormap_name}`);
-  if (params?.resampling_method) qp.push(`resampling_method=${params.resampling_method}`);
-  if (params?.nodata !== undefined) qp.push(`nodata=${params.nodata}`);
-  return `${titiler}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?${qp.join('&')}`;
-}

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -557,20 +557,35 @@ export default function MapCanvas() {
       return;
     }
 
+    const targetHour = isoHourFrom(date, t);
+
     const apply = () => {
       try {
-        const hh = isoHourFrom(date, t);
-        ensureTpHour(map, hh);
+        ensureTpHour(map, targetHour);
       } catch (e) {
         // no-op
       }
     };
 
-    if (!map.isStyleLoaded()) {
-      try { map.once('idle', apply); } catch {}
-    } else {
+    if (map.isStyleLoaded()) {
       apply();
+      return;
     }
+
+    // Fallback: wait for the next render tick where the style reports as loaded.
+    // Using 'idle' is unreliable while the RAF loop is active (map never becomes idle).
+    let cancelled = false;
+    const waitForReady = () => {
+      if (!map.isStyleLoaded()) return;
+      try { map.off('render', waitForReady); } catch {}
+      if (!cancelled) apply();
+    };
+
+    map.on('render', waitForReady);
+    return () => {
+      cancelled = true;
+      try { map.off('render', waitForReady); } catch {}
+    };
   }, [weatherOverlay, t, date]);
 
   // on showFlightLineLabels change, update layer visibility

--- a/src/components/RegulationCanvas.tsx
+++ b/src/components/RegulationCanvas.tsx
@@ -10,13 +10,14 @@ import { Trajectory } from "@/lib/models";
 import RegulationPlanPanel from "@/components/RegulationPlanPanel";
 import RegulationResults from "@/components/RegulationResults";
 import PageLoadingIndicator from "@/components/PageLoadingIndicator";
+import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
 
 export default function RegulationCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
   const rafRef = useRef<number | undefined>(undefined);
   const lastTs = useRef<number>(performance.now());
   const lastUpdateRef = useRef<number>(performance.now());
-  const { t, tick, setRange, showFlightLineLabels, showFlightLines, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, regulationTargetFlightIds, addRegulationTargetFlight, selectedTrafficVolume, isRegulationPanelOpen, isResultsOpen, regulationSimulationResult, setIsResultsOpen, setRegulationSimulationResult, flowViewEnabled, flowCommunities, flowGroups, flowPreviewFlightId, flowPreviewGroupId, focusMode, focusFlightIds, slackMode, setSlackMode, slackSign, deltaMin, setIsFetchingSlack, playing } = useSimStore();
+  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showFlightLines, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, regulationTargetFlightIds, addRegulationTargetFlight, selectedTrafficVolume, isRegulationPanelOpen, isResultsOpen, regulationSimulationResult, setIsResultsOpen, setRegulationSimulationResult, flowViewEnabled, flowCommunities, flowGroups, flowPreviewFlightId, flowPreviewGroupId, focusMode, focusFlightIds, slackMode, setSlackMode, slackSign, deltaMin, setIsFetchingSlack, playing } = useSimStore();
   
   const [highlightedTrafficVolume, setHighlightedTrafficVolume] = useState<string | null>(null);
   const [hoveredTrafficVolume, setHoveredTrafficVolume] = useState<string | null>(null);
@@ -349,6 +350,45 @@ export default function RegulationCanvas() {
 
   // Update regulation highlight when target ids change
   useEffect(() => { updateRegulationHighlight(mapRef.current); }, [regulationTargetFlightIds, flowViewEnabled]);
+
+  // Weather overlay integration (Surface Precipitation)
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (weatherOverlay !== "surface-precip") {
+      hideSurfacePrecipLayer(map);
+      return;
+    }
+
+    const targetHour = isoHourFrom(date, t);
+
+    const apply = () => {
+      try {
+        ensureSurfacePrecipHour(map, targetHour);
+      } catch (e) {
+        // no-op
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      apply();
+      return;
+    }
+
+    let cancelled = false;
+    const waitForReady = () => {
+      if (!map.isStyleLoaded()) return;
+      try { map.off("render", waitForReady); } catch {}
+      if (!cancelled) apply();
+    };
+
+    map.on("render", waitForReady);
+    return () => {
+      cancelled = true;
+      try { map.off("render", waitForReady); } catch {}
+    };
+  }, [weatherOverlay, t, date]);
 
   // on showFlightLineLabels change, toggle visibility
   useEffect(() => {

--- a/src/lib/weatherOverlay.ts
+++ b/src/lib/weatherOverlay.ts
@@ -1,0 +1,94 @@
+import maplibregl from "maplibre-gl";
+
+export const SURFACE_PRECIP_LAYER_ID = "era5_tp";
+
+const LAYER_ORDER_PREFERENCE = [
+  "sector-fill",
+  "sector-outline",
+  "sector-labels",
+  "sector-highlight",
+  "sector-highlight-outline",
+  "sector-hover",
+  "sector-hover-outline",
+  "sector-hotspot",
+  "sector-hotspot-outline",
+  "flight-lines"
+];
+
+const TITILER_BASE = "https://wxtiles.tailwind-api.intuelle.com";
+const COG_BASE = `${TITILER_BASE}/cogs`;
+
+export function isoHourFrom(dateStr: string, t: number): string {
+  const [ddStr, mmStr, yyyyStr] = String(dateStr || "").split("/") as [string, string, string];
+  const dd = Number(ddStr || "1");
+  const mm = Number(mmStr || "1");
+  const yyyy = Number(yyyyStr || "1970");
+  const hour = Math.max(0, Math.min(23, Math.floor((t || 0) / 3600)));
+  const y = String(yyyy).padStart(4, "0");
+  const m = String(mm).padStart(2, "0");
+  const d = String(dd).padStart(2, "0");
+  const h = String(hour).padStart(2, "0");
+  return `${y}-${m}-${d}T${h}`;
+}
+
+type WeatherAwareMap = maplibregl.Map & { __tpHour?: string };
+
+export function ensureSurfacePrecipHour(map: maplibregl.Map, isoHour: string) {
+  if (!map || !map.isStyleLoaded()) return;
+
+  const weatherMap = map as WeatherAwareMap;
+  const prevHour: string | undefined = weatherMap.__tpHour;
+  if (prevHour === isoHour && map.getLayer(SURFACE_PRECIP_LAYER_ID)) {
+    try {
+      map.setPaintProperty(SURFACE_PRECIP_LAYER_ID, "raster-opacity", 0.65);
+    } catch {}
+    return;
+  }
+
+  const cog = encodeURIComponent(`${COG_BASE}/era5_tp_${isoHour}.tif`);
+  const tiles = [buildRasterTile(cog, { rescale: [0, 5], colormap_name: "viridis", resampling_method: "bilinear" })];
+
+  if (map.getLayer(SURFACE_PRECIP_LAYER_ID)) {
+    try { map.removeLayer(SURFACE_PRECIP_LAYER_ID); } catch {}
+  }
+  if (map.getSource(SURFACE_PRECIP_LAYER_ID)) {
+    try { map.removeSource(SURFACE_PRECIP_LAYER_ID); } catch {}
+  }
+
+  const source: maplibregl.RasterSourceSpecification = {
+    type: "raster",
+    tiles,
+    tileSize: 256,
+    attribution: "ECMWF/Copernicus"
+  };
+  map.addSource(SURFACE_PRECIP_LAYER_ID, source);
+
+  const beforeId = LAYER_ORDER_PREFERENCE.find((layerId) => map.getLayer(layerId));
+  const layer: maplibregl.RasterLayerSpecification = {
+    id: SURFACE_PRECIP_LAYER_ID,
+    type: "raster",
+    source: SURFACE_PRECIP_LAYER_ID,
+    paint: { "raster-opacity": 0.65 }
+  };
+  map.addLayer(layer, beforeId);
+
+  weatherMap.__tpHour = isoHour;
+}
+
+export function hideSurfacePrecipLayer(map: maplibregl.Map) {
+  if (!map || !map.isStyleLoaded()) return;
+  try {
+    if (map.getLayer(SURFACE_PRECIP_LAYER_ID)) {
+      map.setPaintProperty(SURFACE_PRECIP_LAYER_ID, "raster-opacity", 0);
+    }
+  } catch {}
+}
+
+function buildRasterTile(urlEncodedCog: string, params?: { rescale?: [number, number]; colormap_name?: string; resampling_method?: string; nodata?: number }): string {
+  const qp: string[] = [`url=${urlEncodedCog}`];
+  if (params?.rescale) qp.push(`rescale=${params.rescale[0]},${params.rescale[1]}`);
+  if (params?.colormap_name) qp.push(`colormap_name=${params.colormap_name}`);
+  if (params?.resampling_method) qp.push(`resampling_method=${params.resampling_method}`);
+  if (params?.nodata !== undefined) qp.push(`nodata=${params.nodata}`);
+  return `${TITILER_BASE}/cog/tiles/WebMercatorQuad/{z}/{x}/{y}.png?${qp.join("&")}`;
+}


### PR DESCRIPTION
## Summary
- extract the surface precipitation tile helpers into a shared weather overlay module
- update MapCanvas to reuse the shared helpers and keep the overlay beneath airspace layers
- enable the same weather overlay behaviour on RegulationCanvas and FlowCanvas when the simulation time or map style changes

## Testing
- npm run lint *(fails: pre-existing lint violations across the project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d6f6d6b0832b8551b1ebd44c96ca