### PR TITLE
Handle unauthorized API responses by logging out

### DIFF
--- a/src/app/api/_utils.ts
+++ b/src/app/api/_utils.ts
@@ -1,4 +1,5 @@
 import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
 
 // Merge base headers with Authorization bearer from the incoming request
 export function withAuth(request: NextRequest, base?: HeadersInit): HeadersInit {
@@ -18,5 +19,36 @@ export function withAuth(request: NextRequest, base?: HeadersInit): HeadersInit 
     merged['Authorization'] = auth;
   }
   return merged;
+}
+
+// Normalize upstream 401 responses so the client can react (e.g. clear token / redirect)
+export async function maybeHandleUnauthorized(
+  resp: Response,
+  fallbackMessage = 'Unauthorized'
+): Promise<NextResponse | null> {
+  if (resp.status !== 401) return null;
+
+  let message = fallbackMessage;
+  try {
+    const raw = await resp.text();
+    const text = raw?.trim();
+    if (text) {
+      try {
+        const parsed = JSON.parse(text);
+        const detail = parsed?.detail ?? parsed?.error ?? parsed?.message ?? parsed?.msg;
+        if (detail) {
+          message = String(detail);
+        } else {
+          message = text;
+        }
+      } catch {
+        message = text;
+      }
+    }
+  } catch {
+    // ignore body parsing errors; fall back to generic message
+  }
+
+  return NextResponse.json({ error: message }, { status: 401 });
 }
 

--- a/src/app/api/automatic_rate_adjustment/route.ts
+++ b/src/app/api/automatic_rate_adjustment/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +11,9 @@ export async function POST(request: NextRequest) {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
 
     if (!resp.ok) {
       const text = await resp.text();

--- a/src/app/api/autorate_occupancy/route.ts
+++ b/src/app/api/autorate_occupancy/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +11,9 @@ export async function POST(request: NextRequest) {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
 
     if (!resp.ok) {
       const text = await resp.text();

--- a/src/app/api/base_evaluation/route.ts
+++ b/src/app/api/base_evaluation/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 // Proxy to backend `/base_evaluation` with JSON POST body
 export async function POST(request: NextRequest) {
@@ -12,6 +12,9 @@ export async function POST(request: NextRequest) {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
 
     if (!resp.ok) {
       const text = await resp.text();

--- a/src/app/api/flow_extraction/route.ts
+++ b/src/app/api/flow_extraction/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 const API_BASE_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
@@ -32,6 +32,10 @@ export async function GET(request: NextRequest) {
 
     const endpoint = `${API_BASE_URL}/flow_extraction?${params.toString()}`;
     const response = await fetch(endpoint, { headers: withAuth(request, { 'Content-Type': 'application/json' }) });
+
+    const unauthorized = await maybeHandleUnauthorized(response);
+    if (unauthorized) return unauthorized;
+
     if (!response.ok) {
       throw new Error(`API responded with status: ${response.status}`);
     }

--- a/src/app/api/flows/route.ts
+++ b/src/app/api/flows/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 // Proxies to backend flows endpoint
 export async function GET(request: NextRequest) {
@@ -74,6 +74,10 @@ export async function GET(request: NextRequest) {
 
     const url = `${backendUrl}/flows?${params.toString()}`;
     const resp = await fetch(url, { headers: withAuth(request, { 'Content-Type': 'application/json' }) });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
+
     if (!resp.ok) {
       const text = await resp.text();
       return NextResponse.json(

--- a/src/app/api/hotspot/route.ts
+++ b/src/app/api/hotspot/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 export async function GET(request: NextRequest) {
   try {
@@ -15,7 +15,10 @@ export async function GET(request: NextRequest) {
       method: 'GET',
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
     });
-    
+
+    const unauthorized = await maybeHandleUnauthorized(response);
+    if (unauthorized) return unauthorized;
+
     if (!response.ok) {
       throw new Error(`Backend API error: ${response.status} ${response.statusText}`);
     }

--- a/src/app/api/original_counts/route.ts
+++ b/src/app/api/original_counts/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 // Proxies to backend original_counts endpoint (POST JSON)
 export async function POST(request: NextRequest) {
@@ -30,6 +30,9 @@ export async function POST(request: NextRequest) {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
 
     const text = await resp.text();
     if (!resp.ok) {

--- a/src/app/api/regulation_plan_simulation/route.ts
+++ b/src/app/api/regulation_plan_simulation/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 // Proxies simulation requests to the backend API `/regulation_plan_simulation`
 export async function POST(request: NextRequest) {
@@ -28,6 +28,9 @@ export async function POST(request: NextRequest) {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
 
     if (!resp.ok) {
       const text = await resp.text();

--- a/src/app/api/regulation_ranking_tv_flights_ordered/route.ts
+++ b/src/app/api/regulation_ranking_tv_flights_ordered/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 const API_BASE_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
@@ -42,6 +42,9 @@ export async function GET(request: NextRequest) {
     const response = await fetch(url.toString(), {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(response);
+    if (unauthorized) return unauthorized;
 
     if (!response.ok) {
       throw new Error(`API responded with status: ${response.status}`);

--- a/src/app/api/simulate_mini/route.ts
+++ b/src/app/api/simulate_mini/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 // Proxy endpoint for simulation. Expects POST with JSON payload
 export async function POST(request: NextRequest) {
@@ -28,6 +28,9 @@ export async function POST(request: NextRequest) {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
       body: JSON.stringify(body),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
 
     if (!resp.ok) {
       const text = await resp.text();

--- a/src/app/api/slack_distribution/route.ts
+++ b/src/app/api/slack_distribution/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 const API_BASE_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
@@ -38,6 +38,9 @@ export async function GET(request: NextRequest) {
     const response = await fetch(url.toString(), {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(response);
+    if (unauthorized) return unauthorized;
 
     if (!response.ok) {
       throw new Error(`API responded with status: ${response.status}`);

--- a/src/app/api/tv_count/route.ts
+++ b/src/app/api/tv_count/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 const API_BASE_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
@@ -21,6 +21,9 @@ export async function GET(request: NextRequest) {
         headers: withAuth(request, { 'Content-Type': 'application/json' }),
       }
     );
+
+    const unauthorized = await maybeHandleUnauthorized(response);
+    if (unauthorized) return unauthorized;
 
     if (!response.ok) {
       throw new Error(`API responded with status: ${response.status}`);

--- a/src/app/api/tv_count_with_capacity/route.ts
+++ b/src/app/api/tv_count_with_capacity/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 const API_BASE_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
@@ -21,6 +21,9 @@ export async function GET(request: NextRequest) {
         headers: withAuth(request, { 'Content-Type': 'application/json' }),
       }
     );
+
+    const unauthorized = await maybeHandleUnauthorized(response);
+    if (unauthorized) return unauthorized;
 
     if (!response.ok) {
       throw new Error(`API responded with status: ${response.status}`);

--- a/src/app/api/tv_flights/route.ts
+++ b/src/app/api/tv_flights/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { withAuth } from '@/app/api/_utils';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
 
 const API_BASE_URL = process.env.BACKEND_URL || 'http://localhost:8000'
 
@@ -24,6 +24,9 @@ export async function GET(request: NextRequest) {
     const response = await fetch(endpoint, {
       headers: withAuth(request, { 'Content-Type': 'application/json' }),
     });
+
+    const unauthorized = await maybeHandleUnauthorized(response);
+    if (unauthorized) return unauthorized;
 
     if (!response.ok) {
       throw new Error(`API responded with status: ${response.status}`);

--- a/src/components/useSimStore.ts
+++ b/src/components/useSimStore.ts
@@ -387,10 +387,8 @@ export const useSimStore = create(persist<State, [], [], Pick<State, 'user'>>((s
   fetchHotspots: async (threshold: number = 0.0) => {
     set({ hotspotsLoading: true });
     try {
-      const token = get().user?.token;
-      const response = await fetch(`/api/hotspot?threshold=${threshold}` , {
-        headers: token ? { Authorization: `Bearer ${token}` } as any : undefined,
-      });
+      const { authFetch } = await import("@/lib/auth");
+      const response = await authFetch(`/api/hotspot?threshold=${threshold}`);
       if (!response.ok) {
         throw new Error(`Failed to fetch hotspots: ${response.statusText}`);
       }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,6 +2,27 @@
 
 import { useSimStore } from "@/components/useSimStore";
 
+let handlingUnauthorized = false;
+
+function handleUnauthorizedRedirect() {
+  if (handlingUnauthorized) return;
+  handlingUnauthorized = true;
+
+  try {
+    useSimStore.getState().logout();
+  } catch (err) {
+    console.error('Failed to clear auth state after 401', err);
+  }
+
+  if (typeof window !== 'undefined') {
+    try {
+      window.location.replace('/login');
+    } catch (err) {
+      console.error('Failed to redirect to /login after 401', err);
+    }
+  }
+}
+
 export function getAuthHeader(): Record<string, string> {
   const token = useSimStore.getState().user?.token;
   return token ? { Authorization: `Bearer ${token}` } : {};
@@ -18,6 +39,12 @@ export async function authFetch(input: RequestInfo | URL, init?: RequestInit) {
     Object.assign(baseHeaders, provided as Record<string, string>);
   }
   const headers = { ...baseHeaders, ...getAuthHeader() } as HeadersInit;
-  return fetch(input as any, { ...(init || {}), headers });
+  const response = await fetch(input as any, { ...(init || {}), headers });
+
+  if (response.status === 401) {
+    handleUnauthorizedRedirect();
+  }
+
+  return response;
 }
 


### PR DESCRIPTION
## Summary
- add a shared helper so API routes can surface upstream 401 responses directly
- update every route proxy to call the helper and stop returning fallback data when unauthorized
- clear persisted auth state and redirect to /login from authFetch when a 401 is encountered, reusing authFetch in the hotspot fetcher

## Testing
- npm run lint *(fails: repository already contains numerous lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ec047dd8832bad30036c95b1d506