### PR TITLE
Add persistent theme toggle with dark mode styling

### DIFF
--- a/src/app/flow-evaluation/page.tsx
+++ b/src/app/flow-evaluation/page.tsx
@@ -65,7 +65,7 @@ export default function FlowEvaluationPage() {
   return (
     <Suspense
       fallback={
-        <main className="min-h-screen w-screen overflow-x-hidden bg-slate-900 relative">
+        <main className="min-h-screen w-screen overflow-x-hidden analytics-surface relative">
           <Header />
           <div className="pt-16 pb-12 px-6">
             <div className="max-w-7xl mx-auto">
@@ -809,7 +809,7 @@ function FlowEvaluationPageContent() {
   }
 
   return (
-    <main className="min-h-screen w-screen overflow-x-hidden bg-slate-900 relative">
+    <main className="min-h-screen w-screen overflow-x-hidden analytics-surface relative">
       <Header />
       <div className="pt-16 pb-12 px-6">
         <div className="max-w-7xl mx-auto">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import '../styles/globals.css'
+import ThemeProvider from '@/components/ThemeProvider'
+import { DEFAULT_THEME, THEMES, THEME_STORAGE_KEY } from '@/styles/theme'
+
+const themeInitScript = `(() => {\n  const themes = ${JSON.stringify(THEMES)};\n  const storageKey = '${THEME_STORAGE_KEY}';\n  const fallback = '${DEFAULT_THEME}';\n  try {\n    const stored = window.localStorage.getItem(storageKey);\n    const parsed = stored ? JSON.parse(stored) : null;\n    const theme = parsed?.state?.theme;\n    const resolved = theme && themes[theme] ? theme : fallback;\n    const root = document.documentElement;\n    root.dataset.theme = resolved;\n    const vars = themes[resolved];\n    Object.keys(vars).forEach((key) => {\n      root.style.setProperty(key, vars[key]);\n    });\n  } catch (error) {\n    const root = document.documentElement;\n    root.dataset.theme = fallback;\n    const vars = themes[fallback];\n    Object.keys(vars).forEach((key) => {\n      root.style.setProperty(key, vars[key]);\n    });\n  }\n})();`;
 
 export const metadata: Metadata = {
   title: 'Flow\'s Kitchen',
@@ -13,7 +18,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <Script id="init-theme" strategy="beforeInteractive">
+          {themeInitScript}
+        </Script>
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   )
 }

--- a/src/app/original_count/page.tsx
+++ b/src/app/original_count/page.tsx
@@ -191,7 +191,7 @@ export default function OriginalCountPage() {
   }
 
   return (
-    <main className="min-h-screen w-screen overflow-x-hidden bg-slate-900 relative">
+    <main className="min-h-screen w-screen overflow-x-hidden analytics-surface relative">
       <Header />
       <div className="pt-16 pb-12 px-6">
         <div className="max-w-7xl mx-auto">

--- a/src/app/solution-comparison/page.tsx
+++ b/src/app/solution-comparison/page.tsx
@@ -515,7 +515,7 @@ export default function SolutionComparisonPage() {
   }
 
   return (
-    <main className="min-h-screen w-screen overflow-x-hidden bg-slate-900 relative">
+    <main className="min-h-screen w-screen overflow-x-hidden analytics-surface relative">
       <Header />
       <div className="pt-16 pb-12 px-6">
         <div className="max-w-7xl mx-auto">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useSimStore } from '@/components/useSimStore';
+import { useThemeStore } from '@/components/useThemeStore';
 import { loadSectors } from '@/lib/airspace';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -18,6 +19,7 @@ export default function Header() {
   
   const router = useRouter();
   const { flights, setFocusMode, setFocusFlightIds, setT, t, setSelectedTrafficVolume, logout, user } = useSimStore();
+  const { theme, toggleTheme } = useThemeStore();
   const pathname = usePathname();
 
   // Load traffic volumes data on component mount
@@ -151,11 +153,11 @@ export default function Header() {
                 Analytics
               </button>
               {showAnalyticsDropdown && (
-                <div className="absolute left-0 top-full mt-2 w-48 bg-white/80 backdrop-blur-sm border border-white/20 rounded-lg shadow-xl z-50">
+                <div className="absolute left-0 top-full mt-2 w-56 glass-menu rounded-lg shadow-xl z-50">
                   <Link
                     href="/original_count"
                     onClick={() => setShowAnalyticsDropdown(false)}
-                    className="block w-full px-4 py-3 text-left text-slate-700 hover:text-slate-900 hover:bg-white/20 transition-colors rounded-lg"
+                    className="block w-full px-4 py-3 text-left text-sm rounded-lg transition-colors hover:bg-[var(--menu-hover-bg)]"
                   >
                     Current Occupancy
                   </Link>
@@ -181,23 +183,23 @@ export default function Header() {
               onKeyPress={handleSearchKeyPress}
               onBlur={handleSearchBlur}
               onFocus={() => searchQuery && setShowSearchResults(true)}
-              className="w-80 px-4 py-2 bg-white/10 backdrop-blur-sm border border-white/20 rounded-full text-white placeholder-white/60 focus:outline-none focus:ring-2 focus:ring-white/30 focus:bg-white/15 transition-all"
+              className="w-80 px-4 py-2 glass-input backdrop-blur-sm rounded-full focus:outline-none focus:ring-2 focus:ring-white/30 focus:bg-[var(--panel-bg-muted)] transition-all"
             />
-            <svg 
-              className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-white/60" 
-              fill="none" 
-              stroke="currentColor" 
+            <svg
+              className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-[var(--panel-text-muted)]"
+              fill="none"
+              stroke="currentColor"
               viewBox="0 0 24 24"
             >
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m21 21-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
             </svg>
             
             {showSearchResults && (
-              <div className="absolute top-full mt-2 w-full bg-white/80 backdrop-blur-sm border border-white/20 rounded-lg shadow-xl max-h-64 overflow-y-auto z-50">
+              <div className="absolute top-full mt-2 w-full glass-menu rounded-lg max-h-64 overflow-y-auto z-50">
                 {isSearching ? (
                   <div className="flex items-center justify-center py-4">
-                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-slate-700"></div>
-                    <span className="ml-2 text-slate-700 text-sm">Searching...</span>
+                    <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-[color:var(--menu-text)]"></div>
+                    <span className="ml-2 text-sm text-[var(--menu-text-muted)]">Searching...</span>
                   </div>
                 ) : searchResults.length > 0 ? (
                   <div className="py-2">
@@ -205,30 +207,30 @@ export default function Header() {
                       <button
                         key={result.id}
                         onClick={() => result.type === 'flight' ? handleFlightSelect(result.flight) : handleTrafficVolumeSelect(result.trafficVolume)}
-                        className="w-full px-4 py-3 text-left hover:bg-white/20 transition-colors border-b border-white/10 last:border-b-0"
+                        className="w-full px-4 py-3 text-left transition-colors border-b border-[var(--menu-border)] last:border-b-0 hover:bg-[var(--menu-hover-bg)]"
                       >
                         {result.type === 'flight' ? (
                           <>
-                            <div className="text-sm font-medium text-slate-900">
+                            <div className="text-sm font-medium text-[var(--menu-text)]">
                               <span className="inline-block w-2 h-2 bg-blue-500 rounded-full mr-2"></span>
                               {result.flight.flightId}
                             </div>
-                            <div className="text-xs text-slate-600">
+                            <div className="text-xs text-[var(--menu-text-muted)]">
                               {result.flight.callSign && `Callsign: ${result.flight.callSign}`}
-                              {result.flight.origin && result.flight.destination && 
+                              {result.flight.origin && result.flight.destination &&
                                 ` • ${result.flight.origin} → ${result.flight.destination}`
                               }
                             </div>
                           </>
                         ) : (
                           <>
-                            <div className="text-sm font-medium text-slate-900">
+                            <div className="text-sm font-medium text-[var(--menu-text)]">
                               <span className="inline-block w-2 h-2 bg-orange-500 rounded-full mr-2"></span>
                               {result.trafficVolume.properties.traffic_volume_id}
                             </div>
-                            <div className="text-xs text-slate-600">
+                            <div className="text-xs text-[var(--menu-text-muted)]">
                               Traffic Volume • FL {result.trafficVolume.properties.min_fl}-{result.trafficVolume.properties.max_fl}
-                              {result.trafficVolume.properties.airspace_id && 
+                              {result.trafficVolume.properties.airspace_id &&
                                 ` • ${result.trafficVolume.properties.airspace_id}`
                               }
                             </div>
@@ -238,7 +240,7 @@ export default function Header() {
                     ))}
                   </div>
                 ) : (
-                  <div className="py-4 px-4 text-sm text-slate-600">
+                  <div className="py-4 px-4 text-sm text-[var(--menu-text-muted)]">
                     No flights or traffic volumes found matching "{searchQuery}"
                   </div>
                 )}
@@ -249,7 +251,7 @@ export default function Header() {
           <div className="relative">
             <button
               onClick={() => setShowDropdown(!showDropdown)}
-              className="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-white/10 transition-colors"
+              className="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-[var(--panel-bg-muted)] transition-colors"
             >
               <div className="w-10 h-10 bg-gradient-to-br from-blue-500 to-purple-600 rounded-full flex items-center justify-center">
                 <span className="text-white font-medium text-sm">NO</span>
@@ -261,30 +263,39 @@ export default function Header() {
             </button>
             
             {showDropdown && (
-              <div className="absolute right-0 top-full mt-2 w-48 bg-white/80 backdrop-blur-sm border border-white/20 rounded-lg shadow-xl">
-                <button 
+              <div className="absolute right-0 top-full mt-2 w-56 glass-menu rounded-lg shadow-xl">
+                <button
                   onClick={async () => {
                     await clearAppCache();
                     setShowDropdown(false);
                     // Give lightweight feedback; keep UX simple for now
                     alert('Cached data cleared');
                   }}
-                  className="w-full px-4 py-3 text-left text-slate-700 hover:text-slate-900 hover:bg-white/20 transition-colors rounded-lg"
+                  className="w-full px-4 py-3 text-left text-sm transition-colors rounded-lg hover:bg-[var(--menu-hover-bg)]"
                 >
                   Clear Cache
                 </button>
-                <button 
+                <button
+                  onClick={() => {
+                    toggleTheme();
+                  }}
+                  className="w-full px-4 py-3 text-left text-sm transition-colors rounded-lg hover:bg-[var(--menu-hover-bg)] flex items-center justify-between"
+                >
+                  <span>Appearance</span>
+                  <span className="text-xs uppercase glass-menu-muted">{theme === 'dark' ? 'Dark' : 'Light'}</span>
+                </button>
+                <button
                   onClick={() => {
                     setShowDropdown(false);
                     logout();
                     router.push('/login');
                   }}
-                  className="w-full px-4 py-3 text-left text-slate-700 hover:text-slate-900 hover:bg-white/20 transition-colors rounded-lg"
+                  className="w-full px-4 py-3 text-left text-sm transition-colors rounded-lg hover:bg-[var(--menu-hover-bg)]"
                 >
                   Sign Out
                 </button>
-                <div className="mx-4 my-2 border-t border-white/30" />
-                <div className="px-4 pb-3 text-xs text-slate-600">
+                <div className="mx-4 my-2 glass-menu-divider" />
+                <div className="px-4 pb-3 text-xs glass-menu-muted">
                   Version 0.24.5 (summerbreeze)
                 </div>
               </div>

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { applyTheme } from "@/styles/theme";
+import { useThemeStore } from "./useThemeStore";
+
+interface ThemeProviderProps {
+  children: ReactNode;
+}
+
+export default function ThemeProvider({ children }: ThemeProviderProps) {
+  const theme = useThemeStore((state) => state.theme);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  useEffect(() => {
+    applyTheme(useThemeStore.getState().theme);
+  }, []);
+
+  return <>{children}</>;
+}

--- a/src/components/useThemeStore.ts
+++ b/src/components/useThemeStore.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import { DEFAULT_THEME, ThemeName, THEMES, THEME_STORAGE_KEY } from "@/styles/theme";
+
+type ThemeState = {
+  theme: ThemeName;
+  setTheme: (theme: ThemeName) => void;
+  toggleTheme: () => void;
+};
+
+const themeNames = Object.keys(THEMES) as ThemeName[];
+
+export const useThemeStore = create(
+  persist<ThemeState>(
+    (set, get) => ({
+      theme: DEFAULT_THEME,
+      setTheme: (theme) => {
+        const next = themeNames.includes(theme) ? theme : DEFAULT_THEME;
+        set({ theme: next });
+      },
+      toggleTheme: () => {
+        const current = get().theme;
+        const idx = themeNames.indexOf(current);
+        const next = idx === -1 ? DEFAULT_THEME : themeNames[(idx + 1) % themeNames.length];
+        set({ theme: next });
+      },
+    }),
+    {
+      name: THEME_STORAGE_KEY,
+      version: 1,
+      partialize: (state) => ({ theme: state.theme }),
+    }
+  )
+);
+

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,6 +5,23 @@
 :root {
   --background: #0f172a;
   --foreground: #f8fafc;
+  --panel-bg: rgba(255, 255, 255, 0.18);
+  --panel-bg-strong: rgba(255, 255, 255, 0.28);
+  --panel-bg-muted: rgba(255, 255, 255, 0.08);
+  --panel-border: rgba(255, 255, 255, 0.22);
+  --panel-divider: rgba(255, 255, 255, 0.18);
+  --panel-text-primary: #f8fafc;
+  --panel-text-muted: rgba(226, 232, 240, 0.72);
+  --panel-shadow: 0 22px 45px -24px rgba(15, 23, 42, 0.55);
+  --menu-bg: rgba(255, 255, 255, 0.85);
+  --menu-hover-bg: rgba(255, 255, 255, 0.95);
+  --menu-border: rgba(148, 163, 184, 0.4);
+  --menu-text: #1e293b;
+  --menu-text-muted: rgba(71, 85, 105, 0.75);
+  --input-bg: rgba(255, 255, 255, 0.12);
+  --input-border: rgba(255, 255, 255, 0.25);
+  --input-placeholder: rgba(248, 250, 252, 0.65);
+  --analytics-background: linear-gradient(180deg, rgba(15,23,42,0.95) 0%, rgba(15,23,42,0.65) 100%);
 }
 
 body {
@@ -31,6 +48,79 @@ a {
   text-decoration: none;
 }
 
+.glass-panel {
+  background-color: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.glass-panel-strong {
+  background-color: var(--panel-bg-strong);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.glass-panel-muted {
+  background-color: var(--panel-bg-muted);
+  border: 1px solid var(--panel-border);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+}
+
+.glass-divider {
+  background-color: var(--panel-divider);
+  border-color: var(--panel-divider);
+}
+
+.glass-input {
+  background-color: var(--input-bg);
+  border: 1px solid var(--input-border);
+  color: var(--panel-text-primary);
+}
+
+.glass-input::placeholder {
+  color: var(--input-placeholder);
+}
+
+.glass-menu {
+  background-color: var(--menu-bg);
+  border: 1px solid var(--menu-border);
+  color: var(--menu-text);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  box-shadow: var(--panel-shadow);
+}
+
+.glass-menu-muted {
+  color: var(--menu-text-muted);
+}
+
+.glass-menu-divider {
+  border-top: 1px solid var(--menu-border);
+}
+
+.analytics-surface {
+  background: var(--analytics-background);
+}
+
+[data-theme='dark'] .bg-white\/20 { background-color: rgba(15, 23, 42, 0.78) !important; }
+[data-theme='dark'] .bg-white\/10 { background-color: rgba(15, 23, 42, 0.65) !important; }
+[data-theme='dark'] .bg-white\/5 { background-color: rgba(15, 23, 42, 0.52) !important; }
+[data-theme='dark'] .bg-white\/0 { background-color: rgba(15, 23, 42, 0.4) !important; }
+[data-theme='dark'] .border-white\/10,
+[data-theme='dark'] .border-white\/15,
+[data-theme='dark'] .border-white\/20,
+[data-theme='dark'] .border-white\/30,
+[data-theme='dark'] .border-white\/40 { border-color: rgba(94, 106, 134, 0.45) !important; }
+[data-theme='dark'] .text-slate-700,
+[data-theme='dark'] .text-slate-600,
+[data-theme='dark'] .text-slate-900 { color: var(--panel-text-primary) !important; }
+[data-theme='dark'] .text-white\/60 { color: var(--panel-text-muted) !important; }
+
 /* Fix MapLibre GL positioning issue */
 .maplibregl-map {
   position: absolute !important;
@@ -38,10 +128,10 @@ a {
 
 /* Hide scrollbars while keeping scroll functionality */
 .no-scrollbar {
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none;
+  scrollbar-width: none;
 }
 
 .no-scrollbar::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera */
+  display: none;
 }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,62 @@
+export type ThemeName = "light" | "dark";
+
+export const THEME_STORAGE_KEY = "theme-preference";
+
+type ThemeVariables = Record<string, string>;
+
+export const THEMES: Record<ThemeName, ThemeVariables> = {
+  light: {
+    "--background": "#0f172a",
+    "--foreground": "#f8fafc",
+    "--panel-bg": "rgba(255, 255, 255, 0.18)",
+    "--panel-bg-strong": "rgba(255, 255, 255, 0.28)",
+    "--panel-bg-muted": "rgba(255, 255, 255, 0.08)",
+    "--panel-border": "rgba(255, 255, 255, 0.22)",
+    "--panel-divider": "rgba(255, 255, 255, 0.18)",
+    "--panel-text-primary": "#f8fafc",
+    "--panel-text-muted": "rgba(226, 232, 240, 0.72)",
+    "--panel-shadow": "0 22px 45px -24px rgba(15, 23, 42, 0.55)",
+    "--menu-bg": "rgba(255, 255, 255, 0.85)",
+    "--menu-hover-bg": "rgba(255, 255, 255, 0.95)",
+    "--menu-border": "rgba(148, 163, 184, 0.4)",
+    "--menu-text": "#1e293b",
+    "--menu-text-muted": "rgba(71, 85, 105, 0.75)",
+    "--input-bg": "rgba(255, 255, 255, 0.12)",
+    "--input-border": "rgba(255, 255, 255, 0.25)",
+    "--input-placeholder": "rgba(248, 250, 252, 0.65)",
+    "--analytics-background": "linear-gradient(180deg, rgba(15,23,42,0.95) 0%, rgba(15,23,42,0.65) 100%)",
+  },
+  dark: {
+    "--background": "#020617",
+    "--foreground": "#e2e8f0",
+    "--panel-bg": "rgba(2, 6, 23, 0.82)",
+    "--panel-bg-strong": "rgba(15, 23, 42, 0.86)",
+    "--panel-bg-muted": "rgba(15, 23, 42, 0.7)",
+    "--panel-border": "rgba(94, 106, 134, 0.45)",
+    "--panel-divider": "rgba(71, 85, 105, 0.45)",
+    "--panel-text-primary": "#e2e8f0",
+    "--panel-text-muted": "rgba(148, 163, 184, 0.8)",
+    "--panel-shadow": "0 22px 55px -28px rgba(2, 6, 23, 0.7)",
+    "--menu-bg": "rgba(15, 23, 42, 0.92)",
+    "--menu-hover-bg": "rgba(30, 41, 59, 0.95)",
+    "--menu-border": "rgba(71, 85, 105, 0.55)",
+    "--menu-text": "#e2e8f0",
+    "--menu-text-muted": "rgba(148, 163, 184, 0.75)",
+    "--input-bg": "rgba(15, 23, 42, 0.65)",
+    "--input-border": "rgba(71, 85, 105, 0.6)",
+    "--input-placeholder": "rgba(148, 163, 184, 0.55)",
+    "--analytics-background": "linear-gradient(180deg, rgba(2,6,23,0.96) 0%, rgba(2,6,23,0.72) 100%)",
+  },
+};
+
+export const DEFAULT_THEME: ThemeName = "light";
+
+export function applyTheme(theme: ThemeName) {
+  if (typeof document === "undefined") return;
+  const palette = THEMES[theme] ?? THEMES[DEFAULT_THEME];
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  for (const [variable, value] of Object.entries(palette)) {
+    root.style.setProperty(variable, value);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a centralized theme palette plus persisted theme store/provider to drive CSS variables across the app
- update the header menus with glass styles and expose an appearance toggle that switches between light and dark modes
- refresh analytics views to use the shared analytics surface while adding global overrides so panel components adopt darker glass surfaces in dark mode

## Testing
- npm run lint *(fails: repository already has numerous pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68ca050e7ec4832b98fb753551bb7eca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added light/dark theme with automatic persistence and instant application on load to prevent flicker.
  - Introduced an Appearance option in the header to toggle themes.

- Style
  - Rolled out a cohesive “glass” UI: updated panels, menus, inputs, dividers, and hover states.
  - Refreshed header search and dropdowns with glass styling, improved widths, and scrollable results.
  - Updated page backgrounds to a new analytics surface for a modern look.
  - Harmonized text and muted states with theme-aware colors for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->