### PR TITLE
feat: darken map canvases for dark theme

### DIFF
--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -8,6 +8,7 @@ import * as turf from "@turf/turf";
 import { useSimStore } from "@/components/useSimStore";
 import PageLoadingIndicator from "@/components/PageLoadingIndicator";
 import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
+import { createFuturisticMapStyle } from "@/lib/mapStyle";
 
 export default function FlowCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
@@ -24,51 +25,7 @@ export default function FlowCanvas() {
   useEffect(() => {
     const map = new maplibregl.Map({
       container: "map",
-      style: {
-        version: 8,
-        sources: {
-          "raster-tiles": {
-            type: "raster",
-            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-            tileSize: 256,
-            attribution: "© OpenStreetMap contributors"
-          },
-          "countries": {
-            type: "vector",
-            url: "https://demotiles.maplibre.org/tiles/tiles.json"
-          }
-        },
-        glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-        layers: [
-          { id: "background", type: "background", paint: { "background-color": "#1e293b" } },
-          {
-            id: "raster-layer",
-            type: "raster",
-            source: "raster-tiles",
-            paint: {
-              "raster-opacity": 0.4,
-              "raster-brightness-min": 0,
-              "raster-brightness-max": 0.3,
-              "raster-contrast": 0.3,
-              "raster-saturation": -0.7
-            }
-          },
-          {
-            id: "countries-fill",
-            type: "fill",
-            source: "countries",
-            "source-layer": "countries",
-            paint: { "fill-color": "#334155", "fill-opacity": 0.3 }
-          },
-          {
-            id: "countries-border",
-            type: "line",
-            source: "countries",
-            "source-layer": "countries",
-            paint: { "line-color": "#64748b", "line-width": 1.5, "line-opacity": 0.8 }
-          }
-        ]
-      },
+      style: createFuturisticMapStyle(256),
       center: [3, 45],
       zoom: 4
     });

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -11,6 +11,7 @@ import { Trajectory } from "@/lib/models";
 import FlightDetailsPopup from "@/components/FlightDetailsPopup";
 import PageLoadingIndicator from "@/components/PageLoadingIndicator";
 import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
+import { createFuturisticMapStyle } from "@/lib/mapStyle";
 
 export default function MapCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
@@ -29,62 +30,7 @@ export default function MapCanvas() {
   useEffect(() => {
     const map = new maplibregl.Map({
       container: "map",
-      style: {
-        version: 8,
-        sources: {
-          "raster-tiles": {
-            type: "raster",
-            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-            tileSize: 512,
-            attribution: "© OpenStreetMap contributors"
-          },
-          "countries": {
-            type: "vector",
-            url: "https://demotiles.maplibre.org/tiles/tiles.json"
-          }
-        },
-        glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-        layers: [
-          {
-            id: "background",
-            type: "background",
-            paint: { "background-color": "#1e293b" }
-          },
-          {
-            id: "raster-layer",
-            type: "raster",
-            source: "raster-tiles",
-            paint: {
-              "raster-opacity": 0.4,
-              "raster-brightness-min": 0,
-              "raster-brightness-max": 0.3,
-              "raster-contrast": 0.3,
-              "raster-saturation": -0.7
-            }
-          },
-          {
-            id: "countries-fill",
-            type: "fill",
-            source: "countries",
-            "source-layer": "countries",
-            paint: {
-              "fill-color": "#334155",
-              "fill-opacity": 0.3
-            }
-          },
-          {
-            id: "countries-border",
-            type: "line",
-            source: "countries",
-            "source-layer": "countries",
-            paint: {
-              "line-color": "#64748b",
-              "line-width": 1.5,
-              "line-opacity": 0.8
-            }
-          }
-        ]
-      },
+      style: createFuturisticMapStyle(512),
       center: [3, 45],
       zoom: 4
     });

--- a/src/components/RegulationCanvas.tsx
+++ b/src/components/RegulationCanvas.tsx
@@ -11,6 +11,7 @@ import RegulationPlanPanel from "@/components/RegulationPlanPanel";
 import RegulationResults from "@/components/RegulationResults";
 import PageLoadingIndicator from "@/components/PageLoadingIndicator";
 import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
+import { createFuturisticMapStyle } from "@/lib/mapStyle";
 
 export default function RegulationCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
@@ -30,51 +31,7 @@ export default function RegulationCanvas() {
   useEffect(() => {
     const map = new maplibregl.Map({
       container: "map",
-      style: {
-        version: 8,
-        sources: {
-          "raster-tiles": {
-            type: "raster",
-            tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
-            tileSize: 256,
-            attribution: "© OpenStreetMap contributors"
-          },
-          "countries": {
-            type: "vector",
-            url: "https://demotiles.maplibre.org/tiles/tiles.json"
-          }
-        },
-        glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
-        layers: [
-          { id: "background", type: "background", paint: { "background-color": "#1e293b" } },
-          {
-            id: "raster-layer",
-            type: "raster",
-            source: "raster-tiles",
-            paint: {
-              "raster-opacity": 0.4,
-              "raster-brightness-min": 0,
-              "raster-brightness-max": 0.3,
-              "raster-contrast": 0.3,
-              "raster-saturation": -0.7
-            }
-          },
-          {
-            id: "countries-fill",
-            type: "fill",
-            source: "countries",
-            "source-layer": "countries",
-            paint: { "fill-color": "#334155", "fill-opacity": 0.3 }
-          },
-          {
-            id: "countries-border",
-            type: "line",
-            source: "countries",
-            "source-layer": "countries",
-            paint: { "line-color": "#64748b", "line-width": 1.5, "line-opacity": 0.8 }
-          }
-        ]
-      },
+      style: createFuturisticMapStyle(256),
       center: [3, 45],
       zoom: 4
     });

--- a/src/lib/mapStyle.ts
+++ b/src/lib/mapStyle.ts
@@ -1,0 +1,74 @@
+import type { StyleSpecification } from "maplibre-gl";
+
+export function createFuturisticMapStyle(tileSize: number): StyleSpecification {
+  return {
+    version: 8,
+    sources: {
+      "raster-tiles": {
+        type: "raster",
+        tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+        tileSize,
+        attribution: "© OpenStreetMap contributors"
+      },
+      countries: {
+        type: "vector",
+        url: "https://demotiles.maplibre.org/tiles/tiles.json"
+      }
+    },
+    glyphs: "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf",
+    layers: [
+      {
+        id: "background",
+        type: "background",
+        paint: {
+          "background-color": "#020617"
+        }
+      },
+      {
+        id: "raster-layer",
+        type: "raster",
+        source: "raster-tiles",
+        paint: {
+          "raster-opacity": 0.32,
+          "raster-brightness-min": 0.05,
+          "raster-brightness-max": 0.28,
+          "raster-contrast": 0.65,
+          "raster-saturation": -0.8,
+          "raster-hue-rotate": 200
+        }
+      },
+      {
+        id: "countries-fill",
+        type: "fill",
+        source: "countries",
+        "source-layer": "countries",
+        paint: {
+          "fill-color": "#0b1220",
+          "fill-opacity": 0.55
+        }
+      },
+      {
+        id: "countries-border-glow",
+        type: "line",
+        source: "countries",
+        "source-layer": "countries",
+        paint: {
+          "line-color": "#0ea5e9",
+          "line-width": 4,
+          "line-opacity": 0.08
+        }
+      },
+      {
+        id: "countries-border",
+        type: "line",
+        source: "countries",
+        "source-layer": "countries",
+        paint: {
+          "line-color": "#38bdf8",
+          "line-width": 1.2,
+          "line-opacity": 0.6
+        }
+      }
+    ]
+  } satisfies StyleSpecification;
+}


### PR DESCRIPTION
## Summary
- add a shared futuristic dark map style helper with deeper background, desaturated tiles, and neon-inspired country edges
- apply the new style across the flow, regulation, and global map canvases for a consistent dark theme

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6bac0370832b867680e085939e57