### PR TITLE
Add regulation comparison snapshots and page

### DIFF
--- a/src/app/regulation-comparison/page.tsx
+++ b/src/app/regulation-comparison/page.tsx
@@ -1,0 +1,1060 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Header from "@/components/Header";
+import TimeScaleControl from "@/components/TimeScaleControl";
+import ModalDialog from "@/components/ModalDialog";
+import MultiSelectWithChips, { ChipOption } from "@/components/MultiSelectWithChips";
+import {
+  RegulationSnapshot,
+  loadRegSnapshots,
+  updateRegSnapshotDescription,
+  deleteRegSnapshot,
+  reorderRegSnapshots,
+  clearRegSnapshots,
+  exportRegSnapshots,
+  importRegSnapshots,
+  MAX_REG_SNAPSHOTS,
+  estimateRegSnapshotsSize,
+  REG_SNAPSHOT_SIZE_WARN_THRESHOLD,
+  REG_SNAPSHOT_STORAGE_KEY,
+} from "@/lib/reg-comparison";
+import { useSimStore } from "@/components/useSimStore";
+import { loadTrajectories } from "@/lib/flights";
+import { hhmmToMinutesSafe, minutesToHHMM, binIndexToRangeLabel } from "@/lib/time";
+import { ResponsiveContainer, ComposedChart, CartesianGrid, XAxis, YAxis, Tooltip, Bar, Line } from "recharts";
+
+const PALETTE = ["#38bdf8", "#f472b6", "#facc15", "#34d399"];
+const ABS_CHANGE_PREFIX = "abs_change:" as const;
+
+type FlightSortMode = "max" | "diff" | "callsign";
+type TvSortMode = "exceedance" | "peak" | "alphabetical" | `${typeof ABS_CHANGE_PREFIX}${string}`;
+
+function getAbsChangeSnapshotId(mode: TvSortMode): string | null {
+  return mode.startsWith(ABS_CHANGE_PREFIX) ? mode.slice(ABS_CHANGE_PREFIX.length) : null;
+}
+
+type FlightRow = {
+  flightId: string;
+  callsign: string;
+  origin?: string;
+  destination?: string;
+  takeoff?: string;
+  delays: Array<{ snapshotId: string; value: number | null }>;
+  maxDelay: number;
+  diffDelay: number;
+};
+
+type TvMetrics = {
+  tvId: string;
+  maxExceedance: number;
+  maxPeak: number;
+};
+
+type AbsChangeSortOption = {
+  value: TvSortMode;
+  label: string;
+  disabled: boolean;
+  reason?: string;
+  snapshotId: string;
+};
+
+function formatNumber(val: number | null | undefined, digits = 2) {
+  if (val === null || val === undefined || Number.isNaN(val)) return "—";
+  if (!Number.isFinite(val)) return "∞";
+  return Number(val).toFixed(digits);
+}
+
+function formatSecondsToHMM(totalSeconds: number | null | undefined): string {
+  if (!Number.isFinite(totalSeconds ?? NaN)) return "—";
+  const s = Math.max(0, Math.floor(totalSeconds as number));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  return `${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;
+}
+
+export default function RegulationComparisonPage() {
+  const router = useRouter();
+  const user = useSimStore((state) => state.user);
+  const { flights, setFlights, setRange } = useSimStore();
+  const [hydrated, setHydrated] = useState(false);
+
+  const [snapshots, setSnapshots] = useState<RegulationSnapshot[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [viewFrom, setViewFrom] = useState("00:00");
+  const [viewTo, setViewTo] = useState("23:59");
+  const [tvSort, setTvSort] = useState<TvSortMode>("exceedance");
+  const [visibleTvCount, setVisibleTvCount] = useState(6);
+  const [selectedTvFilters, setSelectedTvFilters] = useState<string[]>([]);
+  const [flightSort, setFlightSort] = useState<FlightSortMode>("max");
+  const [flightDelayedOnly, setFlightDelayedOnly] = useState(true);
+  const [flightThreshold, setFlightThreshold] = useState(0);
+  const [importOpen, setImportOpen] = useState(false);
+  const [exportOpen, setExportOpen] = useState(false);
+  const [importText, setImportText] = useState("");
+  const [importError, setImportError] = useState<string | null>(null);
+  const [exportText, setExportText] = useState("");
+
+  useEffect(() => {
+    const unsub = useSimStore.persist.onFinishHydration(() => setHydrated(true));
+    setHydrated(useSimStore.persist.hasHydrated());
+    return () => { unsub(); };
+  }, []);
+
+  useEffect(() => {
+    if (hydrated && !user) {
+      router.push("/login");
+    }
+  }, [hydrated, user, router]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const current = loadRegSnapshots();
+    setSnapshots(current);
+    setSelectedIds((prev) => {
+      if (prev.length > 0) return prev.filter((id) => current.some((s) => s.id === id));
+      return current.slice(0, Math.min(2, current.length)).map((s) => s.id);
+    });
+    const onStorage = (ev: StorageEvent) => {
+      if (ev.key && ev.key !== REG_SNAPSHOT_STORAGE_KEY) return;
+      const next = loadRegSnapshots();
+      setSnapshots(next);
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  useEffect(() => {
+    if (flights.length > 0) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const tracks = await loadTrajectories("/data/flights_20230801.csv");
+        if (cancelled) return;
+        setFlights(tracks);
+        if (tracks && tracks.length > 0) {
+          const minT = Math.min(...tracks.map((tr: any) => tr.t0));
+          const maxT = Math.max(...tracks.map((tr: any) => tr.t1));
+          setRange([minT, maxT], minT);
+        }
+      } catch (e) {
+        console.warn("Failed to load flight trajectories for regulation comparison page", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [flights.length, setFlights, setRange]);
+
+  useEffect(() => {
+    setSelectedIds((prev) => {
+      const filtered = prev.filter((id) => snapshots.some((s) => s.id === id));
+      if (filtered.length > 0) return filtered;
+      return snapshots.slice(0, Math.min(2, snapshots.length)).map((s) => s.id);
+    });
+  }, [snapshots]);
+
+  const snapshotSizeBytes = useMemo(() => estimateRegSnapshotsSize(snapshots), [snapshots]);
+  const snapshotSizeWarn = snapshotSizeBytes > REG_SNAPSHOT_SIZE_WARN_THRESHOLD;
+  const snapshotSizeDisplayKb = Math.max(0, Math.round(snapshotSizeBytes / 1024));
+
+  const selectedSnapshots = useMemo(
+    () => selectedIds.map((id) => snapshots.find((s) => s.id === id)).filter(Boolean) as RegulationSnapshot[],
+    [selectedIds, snapshots],
+  );
+
+  const colorBySnapshotId = useMemo(() => {
+    const map = new Map<string, string>();
+    selectedSnapshots.forEach((snap, idx) => {
+      map.set(snap.id, PALETTE[idx % PALETTE.length]);
+    });
+    return map;
+  }, [selectedSnapshots]);
+
+  const minutesBySnapshot = useMemo(() => {
+    const counts = new Map<number, number>();
+    selectedSnapshots.forEach((snap) => {
+      counts.set(snap.minutesPerBin, (counts.get(snap.minutesPerBin) || 0) + 1);
+    });
+    let dominant: number | null = null;
+    counts.forEach((count, minutes) => {
+      if (dominant === null || count > (counts.get(dominant) || 0)) {
+        dominant = minutes;
+      }
+    });
+    return {
+      dominant,
+      mismatched: selectedSnapshots
+        .filter((snap) => dominant !== null && snap.minutesPerBin !== dominant)
+        .map((snap) => snap.id),
+    };
+  }, [selectedSnapshots]);
+
+  const alignedSnapshots = useMemo(() => {
+    if (!minutesBySnapshot.dominant) return selectedSnapshots;
+    return selectedSnapshots.filter((snap) => snap.minutesPerBin === minutesBySnapshot.dominant);
+  }, [selectedSnapshots, minutesBySnapshot]);
+
+  const minutesPerBin = minutesBySnapshot.dominant || (alignedSnapshots[0]?.minutesPerBin ?? 15);
+  const viewFromMin = hhmmToMinutesSafe(viewFrom);
+  const viewToMin = hhmmToMinutesSafe(viewTo);
+
+  const flightsById = useMemo(() => {
+    const map = new Map<string, any>();
+    for (const fl of flights) {
+      if (fl?.flightId) map.set(String(fl.flightId), fl);
+    }
+    return map;
+  }, [flights]);
+
+  const flightRows: FlightRow[] = useMemo(() => {
+    const rows: FlightRow[] = [];
+    const ids = new Set<string>();
+    alignedSnapshots.forEach((snap) => {
+      const delays = snap.delaysMin || {};
+      Object.keys(delays || {}).forEach((fid) => ids.add(String(fid)));
+    });
+    ids.forEach((fid) => {
+      const meta = flightsById.get(fid);
+      const delays = alignedSnapshots.map((snap) => ({
+        snapshotId: snap.id,
+        value: snap.delaysMin?.[fid] != null ? Number(snap.delaysMin?.[fid]) : null,
+      }));
+      const maxDelay = Math.max(0, ...delays.map((d) => (Number.isFinite(d.value ?? NaN) ? Number(d.value) : 0)));
+      const minDelay = Math.min(...delays.map((d) => (Number.isFinite(d.value ?? NaN) ? Number(d.value) : 0)));
+      rows.push({
+        flightId: fid,
+        callsign: meta?.callSign || fid,
+        origin: meta?.origin,
+        destination: meta?.destination,
+        takeoff: meta ? minutesToHHMM(Math.round(meta.t0 / 60)) : undefined,
+        delays,
+        maxDelay,
+        diffDelay: maxDelay - (Number.isFinite(minDelay) ? minDelay : 0),
+      });
+    });
+    let filtered = rows;
+    if (flightDelayedOnly) {
+      filtered = filtered.filter((row) => row.maxDelay > 0);
+    }
+    if (flightThreshold > 0) {
+      filtered = filtered.filter((row) => row.maxDelay >= flightThreshold);
+    }
+    const collator = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
+    filtered.sort((a, b) => {
+      if (flightSort === "callsign") {
+        return collator.compare(a.callsign, b.callsign);
+      }
+      if (flightSort === "diff") {
+        if (b.diffDelay !== a.diffDelay) return b.diffDelay - a.diffDelay;
+        return b.maxDelay - a.maxDelay;
+      }
+      return b.maxDelay - a.maxDelay;
+    });
+    return filtered;
+  }, [alignedSnapshots, flightsById, flightDelayedOnly, flightThreshold, flightSort]);
+
+  const flightColumnStats = useMemo(() => {
+    return alignedSnapshots.map((snap) => {
+      let total = 0;
+      let count = 0;
+      flightRows.forEach((row) => {
+        const entry = row.delays.find((d) => d.snapshotId === snap.id);
+        if (entry && entry.value != null) {
+          total += Number(entry.value);
+          if (entry.value > 0) count += 1;
+        }
+      });
+      const avg = flightRows.length > 0 ? total / flightRows.length : 0;
+      return { snapshotId: snap.id, total, average: avg, delayedCount: count };
+    });
+  }, [alignedSnapshots, flightRows]);
+
+  const bestFlightTotal = useMemo(() => {
+    if (flightColumnStats.length === 0) return null;
+    return Math.min(...flightColumnStats.map((s) => s.total));
+  }, [flightColumnStats]);
+
+  const bestFlightAverage = useMemo(() => {
+    if (flightColumnStats.length === 0) return null;
+    return Math.min(...flightColumnStats.map((s) => s.average));
+  }, [flightColumnStats]);
+
+  const bestTotalDelaySeconds = useMemo(() => {
+    if (selectedSnapshots.length === 0) return null;
+    return Math.min(
+      ...selectedSnapshots.map((snap) => snap.delayStats?.total_delay_seconds ?? Number.POSITIVE_INFINITY),
+    );
+  }, [selectedSnapshots]);
+
+  const bestMeanDelaySeconds = useMemo(() => {
+    if (selectedSnapshots.length === 0) return null;
+    return Math.min(
+      ...selectedSnapshots.map((snap) => snap.delayStats?.mean_delay_seconds ?? Number.POSITIVE_INFINITY),
+    );
+  }, [selectedSnapshots]);
+
+  const tvSeriesBySnapshot = useMemo(() => {
+    const result = new Map<string, Record<string, number[]>>();
+    alignedSnapshots.forEach((snap) => {
+      const aggregated = snap.aggregatedRolling;
+      const series: Record<string, number[]> = {};
+      if (aggregated?.post_counts) {
+        Object.entries(aggregated.post_counts).forEach(([tv, values]) => {
+          if (!Array.isArray(values)) return;
+          series[tv] = values.map((v) => (Number.isFinite(Number(v)) ? Number(v) : 0));
+        });
+      }
+      result.set(snap.id, series);
+    });
+    return result;
+  }, [alignedSnapshots]);
+
+  const capacityBySnapshot = useMemo(() => {
+    const map = new Map<string, Record<string, number[] | undefined>>();
+    alignedSnapshots.forEach((snap) => {
+      const aggregated = snap.aggregatedRolling;
+      const cap: Record<string, number[] | undefined> = {};
+      if (aggregated?.capacity) {
+        Object.entries(aggregated.capacity).forEach(([tv, values]) => {
+          if (!Array.isArray(values)) return;
+          cap[tv] = values.map((v) => (Number.isFinite(Number(v)) ? Number(v) : 0));
+        });
+      }
+      map.set(snap.id, cap);
+    });
+    return map;
+  }, [alignedSnapshots]);
+
+  const tvIdsUnion = useMemo(() => {
+    const set = new Set<string>();
+    alignedSnapshots.forEach((snap) => {
+      const series = tvSeriesBySnapshot.get(snap.id) || {};
+      Object.keys(series).forEach((tv) => set.add(tv));
+    });
+    return Array.from(set);
+  }, [alignedSnapshots, tvSeriesBySnapshot]);
+
+  const tvFilterOptions = useMemo<ChipOption[]>(() => {
+    return tvIdsUnion
+      .slice()
+      .sort((a, b) => a.localeCompare(b))
+      .map((id) => ({ id, label: id }));
+  }, [tvIdsUnion]);
+
+  useEffect(() => {
+    const valid = new Set(tvFilterOptions.map((opt) => opt.id));
+    setSelectedTvFilters((prev) => {
+      const next = prev.filter((id) => valid.has(id));
+      if (next.length === prev.length) return prev;
+      return next;
+    });
+  }, [tvFilterOptions]);
+
+  const selectedTvSet = useMemo(() => new Set(selectedTvFilters.map(String)), [selectedTvFilters]);
+  const hasTvFilter = selectedTvFilters.length > 0;
+
+  const tvMetrics: TvMetrics[] = useMemo(() => {
+    return tvIdsUnion.map((tvId) => {
+      let maxExceedance = 0;
+      let maxPeak = 0;
+      alignedSnapshots.forEach((snap) => {
+        const series = tvSeriesBySnapshot.get(snap.id)?.[tvId] || [];
+        const capacity = capacityBySnapshot.get(snap.id)?.[tvId] || [];
+        for (let i = 0; i < series.length; i++) {
+          const start = i * minutesPerBin;
+          if (start < viewFromMin || start > viewToMin) continue;
+          const val = Number(series[i] ?? 0) || 0;
+          const cap = Number(capacity?.[i] ?? Number.POSITIVE_INFINITY);
+          const exceed = Math.max(0, val - (Number.isFinite(cap) ? cap : 0));
+          if (exceed > maxExceedance) maxExceedance = exceed;
+          if (val > maxPeak) maxPeak = val;
+        }
+      });
+      return { tvId, maxExceedance, maxPeak };
+    });
+  }, [alignedSnapshots, tvIdsUnion, tvSeriesBySnapshot, capacityBySnapshot, minutesPerBin, viewFromMin, viewToMin]);
+
+  const tvAbsChangeBySnapshot = useMemo(() => {
+    const map = new Map<string, Record<string, number>>();
+    alignedSnapshots.forEach((snap) => {
+      const aggregated = snap.aggregatedRolling;
+      if (!aggregated) {
+        map.set(snap.id, {});
+        return;
+      }
+      const pre = aggregated.pre_counts || {};
+      const post = aggregated.post_counts || {};
+      const tvIds = new Set<string>([...Object.keys(pre), ...Object.keys(post)]);
+      const entries: Record<string, number> = {};
+      const minutes = Number(aggregated.time_bin_minutes || minutesPerBin || snap.minutesPerBin || 15);
+      tvIds.forEach((tvId) => {
+        const preSeries = pre?.[tvId] || [];
+        const postSeries = post?.[tvId] || [];
+        const n = Math.min(preSeries.length, postSeries.length);
+        let score = 0;
+        for (let i = 0; i < n; i++) {
+          const start = i * minutes;
+          if (start < viewFromMin || start > viewToMin) continue;
+          const a = Number(preSeries[i] ?? 0);
+          const b = Number(postSeries[i] ?? 0);
+          score += Math.abs((Number.isFinite(b) ? b : 0) - (Number.isFinite(a) ? a : 0));
+        }
+        entries[tvId] = score;
+      });
+      map.set(snap.id, entries);
+    });
+    return map;
+  }, [alignedSnapshots, minutesPerBin, viewFromMin, viewToMin]);
+
+  const absChangeSortOptions = useMemo<AbsChangeSortOption[]>(() => {
+    return alignedSnapshots.map((snap) => {
+      const aggregated = snap.aggregatedRolling;
+      const preCount = Object.keys(aggregated?.pre_counts || {}).length;
+      const postCount = Object.keys(aggregated?.post_counts || {}).length;
+      let disabled = false;
+      let reason: string | undefined;
+      if (!aggregated || postCount === 0) {
+        disabled = true;
+        reason = "Snapshot is missing post-rolling counts.";
+      } else if (preCount === 0) {
+        disabled = true;
+        reason = "Snapshot is missing baseline rolling counts.";
+      }
+      return {
+        value: `${ABS_CHANGE_PREFIX}${snap.id}` as TvSortMode,
+        label: `Rank by Absolute Change (${snap.description || "Untitled"})`,
+        disabled,
+        reason,
+        snapshotId: snap.id,
+      };
+    });
+  }, [alignedSnapshots]);
+
+  useEffect(() => {
+    const snapshotId = getAbsChangeSnapshotId(tvSort);
+    if (!snapshotId) return;
+    const option = absChangeSortOptions.find((opt) => opt.snapshotId === snapshotId);
+    if (!option || option.disabled) {
+      if (tvSort !== "exceedance") setTvSort("exceedance");
+    }
+  }, [absChangeSortOptions, tvSort]);
+
+  const filteredTvIds = useMemo(() => {
+    let list = tvMetrics;
+    if (hasTvFilter) {
+      list = list.filter((item) => selectedTvSet.has(item.tvId));
+    }
+    const absChangeSnapshotId = getAbsChangeSnapshotId(tvSort);
+    const absScores = absChangeSnapshotId ? tvAbsChangeBySnapshot.get(absChangeSnapshotId) || null : null;
+    const collator = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
+    const sorted = [...list];
+    sorted.sort((a, b) => {
+      if (absScores) {
+        const scoreA = absScores[a.tvId] ?? 0;
+        const scoreB = absScores[b.tvId] ?? 0;
+        if (scoreB !== scoreA) return scoreB - scoreA;
+        return collator.compare(a.tvId, b.tvId);
+      }
+      if (tvSort === "alphabetical") {
+        return collator.compare(a.tvId, b.tvId);
+      }
+      if (tvSort === "peak") {
+        if (b.maxPeak !== a.maxPeak) return b.maxPeak - a.maxPeak;
+        return b.maxExceedance - a.maxExceedance;
+      }
+      if (b.maxExceedance !== a.maxExceedance) return b.maxExceedance - a.maxExceedance;
+      return b.maxPeak - a.maxPeak;
+    });
+    return sorted.map((item) => item.tvId);
+  }, [tvMetrics, hasTvFilter, selectedTvSet, tvSort, tvAbsChangeBySnapshot]);
+
+  const visibleTvs = filteredTvIds.slice(0, visibleTvCount);
+
+  if (!hydrated || !user) {
+    return null;
+  }
+
+  return (
+    <main className="min-h-screen w-screen overflow-x-hidden analytics-surface relative">
+      <Header />
+      <div className="pt-16 pb-12 px-6">
+        <div className="max-w-7xl mx-auto">
+          <div className="mb-6">
+            <div className="text-[11px] uppercase tracking-wider text-white/70">Analytics</div>
+            <h1 className="text-2xl font-semibold text-white">Regulation Comparison</h1>
+            <div className="text-[12px] text-white/60 mt-1">Compare up to {MAX_REG_SNAPSHOTS} saved regulation plan simulations.</div>
+          </div>
+
+          <section className="bg-white/5 border border-white/10 rounded-xl p-4 mb-6 space-y-4">
+            <div className="flex flex-wrap items-center gap-3 justify-between">
+              <div className="flex items-center gap-3 text-[12px] text-white/70">
+                <span>{snapshots.length} snapshot(s) stored</span>
+                <span className={snapshotSizeWarn ? "text-amber-200" : "text-white/70"}>~{snapshotSizeDisplayKb} KB in storage</span>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 text-[12px]">
+                <button
+                  onClick={() => {
+                    setExportText(exportRegSnapshots());
+                    setExportOpen(true);
+                  }}
+                  className="px-2.5 py-1 rounded-md border border-white/20 bg-white/10 text-white/80 hover:bg-white/15"
+                >Export</button>
+                <button
+                  onClick={() => { setImportText(""); setImportError(null); setImportOpen(true); }}
+                  className="px-2.5 py-1 rounded-md border border-white/20 bg-white/10 text-white/80 hover:bg-white/15"
+                >Import</button>
+                <button
+                  onClick={() => { clearRegSnapshots(); setSnapshots([]); setSelectedIds([]); }}
+                  className="px-2.5 py-1 rounded-md border border-white/20 bg-red-500/20 text-red-100 hover:bg-red-500/30"
+                >Clear all</button>
+                <a
+                  href="/regulations"
+                  className="px-2.5 py-1 rounded-md border border-emerald-400/60 bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/25"
+                >Collect new snapshot</a>
+              </div>
+            </div>
+
+            {selectedSnapshots.length === 0 && (
+              <div className="text-sm text-white/70 bg-white/5 border border-white/10 rounded-lg p-4">
+                Select at least one snapshot to begin.
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {snapshots.length === 0 && (
+                <div className="col-span-full text-white/60 text-sm bg-white/5 border border-white/10 rounded-lg p-4">
+                  No saved regulation results yet. Run a simulation and click “Add to Comparison” from the results modal.
+                </div>
+              )}
+              {snapshots.map((snap, idx) => {
+                const selected = selectedIds.includes(snap.id);
+                const color = colorBySnapshotId.get(snap.id) || PALETTE[idx % PALETTE.length];
+                const mismatched = minutesBySnapshot.mismatched.includes(snap.id);
+                return (
+                  <div key={snap.id} className={`rounded-lg border p-3 bg-white/5 space-y-3 ${selected ? 'border-emerald-300/70' : 'border-white/10'}`}>
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex-1 space-y-1">
+                        <div className="flex items-center gap-2">
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={(e) => {
+                              const checked = e.currentTarget.checked;
+                              setSelectedIds((prev) => {
+                                if (checked) {
+                                  if (prev.includes(snap.id)) return prev;
+                                  if (prev.length >= MAX_REG_SNAPSHOTS) return prev;
+                                  return [...prev, snap.id];
+                                }
+                                return prev.filter((id) => id !== snap.id);
+                              });
+                            }}
+                          />
+                          <div className="w-2 h-2 rounded-full" style={{ background: color }} />
+                          <span className={`text-[10px] uppercase tracking-wider ${mismatched ? 'text-amber-300' : 'text-white/50'}`}>
+                            {snap.minutesPerBin} min bins
+                          </span>
+                        </div>
+                        <input
+                          value={snap.description || "Untitled"}
+                          onChange={(e) => {
+                            const val = e.currentTarget.value;
+                            setSnapshots((prev) => prev.map((s) => s.id === snap.id ? { ...s, description: val } : s));
+                          }}
+                          onBlur={(e) => {
+                            const val = e.currentTarget.value.trim() || "Untitled";
+                            if (val === snap.description) return;
+                            try {
+                              const next = updateRegSnapshotDescription(snap.id, val);
+                              setSnapshots(next);
+                            } catch (err) {
+                              console.warn("Failed to rename regulation snapshot", err);
+                            }
+                          }}
+                          className="w-full px-2 py-1 rounded-md bg-white/10 border border-white/15 text-sm text-white focus:border-white/40"
+                        />
+                        <div className="text-[12px] text-white/60">
+                          Saved {new Date(snap.createdAt).toLocaleString()}
+                        </div>
+                      </div>
+                      <div className="flex flex-col gap-2 items-end">
+                        <button
+                          onClick={() => {
+                            try {
+                              const next = deleteRegSnapshot(snap.id);
+                              setSnapshots(next);
+                            } catch (err) {
+                              console.warn("Failed to delete regulation snapshot", err);
+                            }
+                          }}
+                          className="text-[11px] text-red-200 hover:text-red-100"
+                        >Delete</button>
+                        <div className="flex flex-col gap-1 text-[11px] text-white/70">
+                          <button
+                            onClick={() => {
+                              const idxCurrent = snapshots.findIndex((s) => s.id === snap.id);
+                              if (idxCurrent <= 0) return;
+                              const ids = [...snapshots.map((s) => s.id)];
+                              const [removed] = ids.splice(idxCurrent, 1);
+                              ids.splice(idxCurrent - 1, 0, removed);
+                              const reordered = reorderRegSnapshots(ids);
+                              setSnapshots(reordered);
+                            }}
+                            className="hover:text-white"
+                          >Move ↑</button>
+                          <button
+                            onClick={() => {
+                              const idxCurrent = snapshots.findIndex((s) => s.id === snap.id);
+                              if (idxCurrent < 0 || idxCurrent >= snapshots.length - 1) return;
+                              const ids = [...snapshots.map((s) => s.id)];
+                              const [removed] = ids.splice(idxCurrent, 1);
+                              ids.splice(idxCurrent + 1, 0, removed);
+                              const reordered = reorderRegSnapshots(ids);
+                              setSnapshots(reordered);
+                            }}
+                            className="hover:text-white"
+                          >Move ↓</button>
+                        </div>
+                      </div>
+                    </div>
+                    {mismatched && (
+                      <div className="text-[11px] text-amber-200 bg-amber-500/10 border border-amber-400/40 rounded-md p-2">
+                        Bin size {snap.minutesPerBin} differs from dominant {minutesBySnapshot.dominant} min. Charts use matching snapshots only.
+                      </div>
+                    )}
+                    <div className="grid grid-cols-2 gap-2 text-[12px] text-white/70">
+                      <div>
+                        <div className="text-white/50 uppercase text-[10px] tracking-wider">Total delay (min)</div>
+                        <div className="font-mono text-white/90">{formatNumber((snap.delayStats?.total_delay_seconds ?? 0) / 60, 1)}</div>
+                      </div>
+                      <div>
+                        <div className="text-white/50 uppercase text-[10px] tracking-wider">Mean delay (min)</div>
+                        <div className="font-mono text-white/90">{formatNumber((snap.delayStats?.mean_delay_seconds ?? 0) / 60, 2)}</div>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="bg-white/5 border border-white/10 rounded-xl p-4 mb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold text-white">Delay comparison</h2>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
+              {selectedSnapshots.map((snap) => {
+                const color = colorBySnapshotId.get(snap.id) || "#fff";
+                const stats = snap.delayStats;
+                const totalSeconds = stats?.total_delay_seconds ?? 0;
+                const meanSeconds = stats?.mean_delay_seconds ?? 0;
+                const maxSeconds = stats?.max_delay_seconds ?? 0;
+                const minSeconds = stats?.min_delay_seconds ?? 0;
+                const delayedFlights = stats?.delayed_flights_count ?? 0;
+                const totalFlights = stats?.num_flights ?? 0;
+                const isBestTotal = bestTotalDelaySeconds != null && totalSeconds === bestTotalDelaySeconds;
+                const isBestMean = bestMeanDelaySeconds != null && meanSeconds === bestMeanDelaySeconds;
+                return (
+                  <div key={snap.id} className="rounded-lg border border-white/10 bg-white/5 p-4 text-white/80 space-y-2">
+                    <div className="flex items-center gap-2 text-sm font-semibold">
+                      <span className="inline-flex w-2 h-2 rounded-full" style={{ background: color }} />
+                      <span>{snap.description || "Untitled"}</span>
+                      {isBestTotal && <span className="text-[10px] uppercase tracking-wider bg-emerald-500/20 border border-emerald-400/60 px-1.5 py-0.5 rounded text-emerald-100">Lowest total</span>}
+                    </div>
+                    <div className="text-[12px] text-white/60">Total delay</div>
+                    <div className="text-2xl font-semibold text-white">{formatNumber(totalSeconds / 60, 1)} min</div>
+                    <div className="text-[12px] text-white/60">{formatSecondsToHMM(totalSeconds)}</div>
+                    <div className={`text-sm ${isBestMean ? 'text-emerald-300' : 'text-white/70'}`}>Mean {formatNumber(meanSeconds / 60, 2)} min</div>
+                    <div className="text-[12px] text-white/70">Max {formatNumber(maxSeconds / 60, 2)} min</div>
+                    <div className="text-[12px] text-white/70">Min {formatNumber(minSeconds / 60, 2)} min</div>
+                    <div className="text-[12px] text-white/70">Delayed flights {delayedFlights.toLocaleString()} / {totalFlights.toLocaleString()}</div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <section className="bg-white/5 border border-white/10 rounded-xl p-4 mb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold text-white">Flight delay comparison</h2>
+              <div className="flex flex-wrap items-center gap-3 text-[12px] text-white/70">
+                <label className="inline-flex items-center gap-2">
+                  <input type="checkbox" checked={flightDelayedOnly} onChange={(e) => setFlightDelayedOnly(e.currentTarget.checked)} />
+                  Only delayed flights
+                </label>
+                <label className="inline-flex items-center gap-2">
+                  Threshold ≥
+                  <input
+                    type="number"
+                    value={flightThreshold}
+                    onChange={(e) => setFlightThreshold(Math.max(0, Number(e.currentTarget.value) || 0))}
+                    className="w-16 px-2 py-1 rounded-md bg-white/10 border border-white/20 text-white"
+                  />
+                  min
+                </label>
+                <select
+                  value={flightSort}
+                  onChange={(e) => setFlightSort(e.currentTarget.value as FlightSortMode)}
+                  className="px-2 py-1 rounded-md bg-white/10 border border-white/20 text-white"
+                >
+                  <option value="max">Sort by max delay</option>
+                  <option value="diff">Sort by diff</option>
+                  <option value="callsign">Sort by callsign</option>
+                </select>
+              </div>
+            </div>
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full text-sm text-white/80">
+                <thead className="text-white/60 text-[12px] uppercase tracking-wider">
+                  <tr>
+                    <th className="text-left px-3 py-2">Flight</th>
+                    <th className="text-left px-3 py-2">Origin</th>
+                    <th className="text-left px-3 py-2">Destination</th>
+                    <th className="text-left px-3 py-2">Takeoff</th>
+                    {alignedSnapshots.map((snap) => (
+                      <th key={snap.id} className="text-right px-3 py-2">
+                        <div className="flex items-center justify-end gap-1">
+                          <span className="inline-flex w-2 h-2 rounded-full" style={{ background: colorBySnapshotId.get(snap.id) || '#fff' }} />
+                          <span>{snap.description || "Untitled"}</span>
+                        </div>
+                      </th>
+                    ))}
+                    <th className="text-right px-3 py-2">Max</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {flightRows.length === 0 && (
+                    <tr>
+                      <td colSpan={5 + alignedSnapshots.length} className="px-3 py-6 text-center text-white/50">
+                        No flights meet the current filters.
+                      </td>
+                    </tr>
+                  )}
+                  {flightRows.map((row) => {
+                    const maxValueRaw = Math.max(...row.delays.map((d) => Number(d.value ?? 0)));
+                    const highlightValue = maxValueRaw > 0 ? maxValueRaw : null;
+                    return (
+                      <tr key={row.flightId} className="border-t border-white/10">
+                        <td className="px-3 py-2 font-mono text-[13px] text-white/90">{row.callsign}</td>
+                        <td className="px-3 py-2">{row.origin || '—'}</td>
+                        <td className="px-3 py-2">{row.destination || '—'}</td>
+                        <td className="px-3 py-2 font-mono text-[13px]">{row.takeoff || '—'}</td>
+                        {row.delays.map((delay) => (
+                          <td
+                            key={delay.snapshotId}
+                            className={`px-3 py-2 text-right font-mono text-[13px] ${highlightValue != null && delay.value != null && delay.value === highlightValue ? 'bg-white/10 text-white' : 'text-white/80'}`}
+                          >
+                            {formatNumber(delay.value, 1)}
+                          </td>
+                        ))}
+                        <td className="px-3 py-2 text-right font-mono text-[13px] text-white/90">{formatNumber(row.maxDelay, 1)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+                {flightRows.length > 0 && (
+                  <tfoot className="border-t border-white/15 text-[12px] text-white/70">
+                    <tr>
+                      <td className="px-3 py-2" colSpan={4}>Total delay (minutes)</td>
+                      {alignedSnapshots.map((snap) => {
+                        const stat = flightColumnStats.find((s) => s.snapshotId === snap.id);
+                        const isBest = stat && bestFlightTotal != null && stat.total === bestFlightTotal;
+                        return (
+                          <td key={snap.id} className={`px-3 py-2 text-right font-mono text-[12px] ${isBest ? 'text-emerald-200' : 'text-white/70'}`}>
+                            {formatNumber(stat?.total ?? null, 1)}
+                          </td>
+                        );
+                      })}
+                      <td className="px-3 py-2 text-right">—</td>
+                    </tr>
+                    <tr>
+                      <td className="px-3 py-2" colSpan={4}>Average per flight</td>
+                      {alignedSnapshots.map((snap) => {
+                        const stat = flightColumnStats.find((s) => s.snapshotId === snap.id);
+                        const isBest = stat && bestFlightAverage != null && stat.average === bestFlightAverage;
+                        return (
+                          <td key={`${snap.id}-avg`} className={`px-3 py-2 text-right font-mono text-[12px] ${isBest ? 'text-emerald-200' : 'text-white/70'}`}>
+                            {formatNumber(stat?.average ?? null, 2)}
+                          </td>
+                        );
+                      })}
+                      <td className="px-3 py-2 text-right">—</td>
+                    </tr>
+                  </tfoot>
+                )}
+              </table>
+            </div>
+          </section>
+
+          <section className="bg-white/5 border border-white/10 rounded-xl p-4 mb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="text-white/70 text-sm">Time window</div>
+              <div className="text-[12px] text-white/60">Filtering charts and tables to {viewFrom} – {viewTo}</div>
+            </div>
+            <div className="mt-3">
+              <TimeScaleControl
+                time_from={viewFrom}
+                time_to={viewTo}
+                onCommit={(from, to) => { setViewFrom(from); setViewTo(to); }}
+              />
+            </div>
+          </section>
+
+          <section className="bg-white/5 border border-white/10 rounded-xl p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+              <h2 className="text-lg font-semibold text-white">Traffic volume occupancy</h2>
+              <div className="flex flex-wrap items-center gap-3 text-[12px] text-white/70 justify-end w-full sm:w-auto">
+                <select
+                  value={tvSort}
+                  onChange={(e) => setTvSort(e.currentTarget.value as TvSortMode)}
+                  className="h-[42px] px-3 rounded-md bg-white/10 border border-white/20 text-white"
+                >
+                  <option value="exceedance">Sort by exceedance</option>
+                  <option value="peak">Sort by peak</option>
+                  <option value="alphabetical">Sort alphabetically</option>
+                  {absChangeSortOptions.map((option) => (
+                    <option
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      title={option.reason}
+                    >
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+                <div className="min-w-[220px] sm:min-w-[260px] w-full sm:w-[260px]">
+                  <MultiSelectWithChips
+                    options={tvFilterOptions}
+                    selectedIds={selectedTvFilters}
+                    onChange={(ids) => { setSelectedTvFilters(ids); setVisibleTvCount(6); }}
+                    placeholder="Filter traffic volumes"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {visibleTvs.length === 0 && (
+              <div className="text-sm text-white/60 bg-white/5 border border-white/10 rounded-lg p-4">
+                No traffic volumes match the current filters.
+              </div>
+            )}
+            {visibleTvs.length === 0 && alignedSnapshots.length > 0 && tvIdsUnion.length === 0 && (
+              <div className="text-sm text-amber-200 bg-amber-500/10 border border-amber-400/30 rounded-lg p-4 mt-3">
+                The selected snapshots do not include rolling occupancy data. Save new snapshots after rerunning the simulation.
+              </div>
+            )}
+
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              {visibleTvs.map((tvId) => {
+                const chartData: Array<Record<string, any>> = [];
+                let maxBins = alignedSnapshots.reduce((max, snap) => {
+                  const series = tvSeriesBySnapshot.get(snap.id)?.[tvId] || [];
+                  return Math.max(max, series.length);
+                }, 0);
+                const capacitySeries = capacityBySnapshot.get(alignedSnapshots[0]?.id || "")?.[tvId];
+                if (capacitySeries && Array.isArray(capacitySeries)) {
+                  maxBins = Math.max(maxBins, capacitySeries.length);
+                }
+                for (let i = 0; i < maxBins; i++) {
+                  const start = i * minutesPerBin;
+                  if (start < viewFromMin || start > viewToMin) continue;
+                  const entry: Record<string, any> = { idx: i, label: binIndexToRangeLabel(i, minutesPerBin) };
+                  let hasValue = false;
+                  alignedSnapshots.forEach((snap) => {
+                    const series = tvSeriesBySnapshot.get(snap.id)?.[tvId] || [];
+                    const val = Number(series[i] ?? 0) || 0;
+                    if (val !== 0) hasValue = true;
+                    entry[snap.id] = val;
+                  });
+                  if (capacitySeries && Array.isArray(capacitySeries)) {
+                    entry.capacity = Number(capacitySeries[i] ?? 0);
+                    if (entry.capacity) hasValue = true;
+                  }
+                  if (hasValue) chartData.push(entry);
+                }
+
+                const legendMetrics = alignedSnapshots.map((snap) => {
+                  const series = tvSeriesBySnapshot.get(snap.id)?.[tvId] || [];
+                  const capacity = capacityBySnapshot.get(snap.id)?.[tvId] || [];
+                  let peak = 0;
+                  let exceedance = 0;
+                  for (let i = 0; i < series.length; i++) {
+                    const start = i * minutesPerBin;
+                    if (start < viewFromMin || start > viewToMin) continue;
+                    const val = Number(series[i] ?? 0) || 0;
+                    if (val > peak) peak = val;
+                    const cap = Number(capacity?.[i] ?? Number.POSITIVE_INFINITY);
+                    if (Number.isFinite(cap)) {
+                      exceedance += Math.max(0, val - cap);
+                    }
+                  }
+                  return { snap, peak, exceedance };
+                });
+
+                const hasCapacity = Array.isArray(capacitySeries) && capacitySeries.length > 0;
+                const hasSeries = alignedSnapshots.some((snap) => (tvSeriesBySnapshot.get(snap.id)?.[tvId] || []).length > 0);
+
+                return (
+                  <div key={tvId} className="rounded-lg border border-white/10 bg-white/5 p-3 space-y-3">
+                    <div className="flex items-center justify-between">
+                      <div className="text-sm font-semibold text-white">{tvId}</div>
+                    </div>
+                    <div className="h-48">
+                      {hasSeries || hasCapacity ? (
+                        <ResponsiveContainer width="100%" height="100%">
+                          <ComposedChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 8 }}>
+                            <CartesianGrid stroke="rgba(255,255,255,0.08)" vertical={false} />
+                            <XAxis dataKey="label" tick={{ fontSize: 10, fill: "#cbd5f5" }} interval="preserveStartEnd" />
+                            <YAxis tick={{ fontSize: 10, fill: "#cbd5f5" }} width={40} allowDecimals={false} />
+                            <Tooltip
+                              wrapperStyle={{ zIndex: 20 }}
+                              contentStyle={{ background: "rgba(15,23,42,0.95)", border: "1px solid rgba(255,255,255,0.15)", borderRadius: 8, color: "white" }}
+                              labelStyle={{ color: "white" }}
+                              formatter={(value: any, name: any) => [String(value), name]}
+                            />
+                            {hasCapacity && <Line type="monotone" dataKey="capacity" name="Capacity" stroke="#f87171" strokeWidth={1.8} dot={false} />}
+                            {alignedSnapshots.map((snap) => (
+                              <Bar
+                                key={snap.id}
+                                dataKey={snap.id}
+                                name={snap.description || 'Untitled'}
+                                fill={colorBySnapshotId.get(snap.id) || '#fff'}
+                                barSize={Math.max(6, 28 / Math.max(1, alignedSnapshots.length))}
+                              />
+                            ))}
+                          </ComposedChart>
+                        </ResponsiveContainer>
+                      ) : (
+                        <div className="h-full flex items-center justify-center text-sm text-white/50">
+                          No occupancy data for this TV in the selected snapshots.
+                        </div>
+                      )}
+                    </div>
+                    <div className="space-y-1 text-[12px] text-white/70">
+                      {legendMetrics.map(({ snap, peak, exceedance }) => (
+                        <div key={snap.id} className="flex items-center gap-2">
+                          <span className="inline-flex w-2 h-2 rounded-full" style={{ background: colorBySnapshotId.get(snap.id) || '#fff' }} />
+                          <span className="text-white/80">{snap.description || 'Untitled'}</span>
+                          <span className="text-white/60">Peak {formatNumber(peak, 1)}</span>
+                          <span className="text-white/60">Exceedance {formatNumber(exceedance, 1)}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            {visibleTvCount < filteredTvIds.length && (
+              <div className="flex justify-center mt-4">
+                <button
+                  onClick={() => setVisibleTvCount((c) => Math.min(filteredTvIds.length, c + 6))}
+                  className="px-3 py-1.5 rounded-md border border-white/20 bg-white/10 text-white/80 hover:bg-white/15 text-sm"
+                >Show more</button>
+              </div>
+            )}
+
+            {alignedSnapshots.length !== selectedSnapshots.length && (
+              <div className="mt-4 text-[12px] text-amber-200">
+                Ignoring {selectedSnapshots.length - alignedSnapshots.length} snapshot(s) with mismatched bin sizes for charts and tables.
+              </div>
+            )}
+          </section>
+        </div>
+      </div>
+
+      <ModalDialog
+        open={exportOpen}
+        onClose={() => setExportOpen(false)}
+        title="Export snapshots"
+        width="w-[min(720px,95vw)]"
+        height="h-auto max-h-[80vh]"
+      >
+        <div className="p-6 space-y-4 text-sm">
+          <p className="text-white/70">Copy the JSON below to share or backup your saved regulation results.</p>
+          <textarea
+            value={exportText}
+            onChange={(e) => setExportText(e.currentTarget.value)}
+            className="w-full min-h-[320px] bg-black/40 border border-white/20 rounded-lg p-3 font-mono text-xs text-white"
+          />
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={() => {
+                try {
+                  const data = exportText || "";
+                  const blob = new Blob([data], { type: "application/json;charset=utf-8" });
+                  const url = URL.createObjectURL(blob);
+                  const now = new Date();
+                  const pad = (n: number) => String(n).padStart(2, "0");
+                  const filename = `reg_snapshots_${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}${pad(now.getSeconds())}.json`;
+                  const a = document.createElement("a");
+                  a.href = url;
+                  a.download = filename;
+                  document.body.appendChild(a);
+                  a.click();
+                  document.body.removeChild(a);
+                  URL.revokeObjectURL(url);
+                } catch (e) {
+                  console.warn("Failed to download export JSON", e);
+                }
+              }}
+              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-emerald-300 bg-emerald-500/30 text-emerald-50 hover:bg-emerald-500/40"
+            >
+              <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path d="M9 3a1 1 0 0 1 2 0v8.586l2.293-2.293a1 1 0 1 1 1.414 1.414l-4 4a1 1 0 0 1-1.414 0l-4-4A1 1 0 0 1 6.707 9.293L9 11.586V3z" />
+                <path d="M4 15a1 1 0 0 1 1-1h10a1 1 0 1 1 0 2H5a1 1 0 0 1-1-1z" />
+              </svg>
+              <span>Download JSON</span>
+            </button>
+            <button
+              onClick={() => setExportOpen(false)}
+              className="px-3 py-1.5 rounded-md border border-white/20 bg-white/10 text-white/80 hover:bg-white/15"
+            >Close</button>
+          </div>
+        </div>
+      </ModalDialog>
+
+      <ModalDialog
+        open={importOpen}
+        onClose={() => { setImportOpen(false); setImportError(null); }}
+        title="Import snapshots"
+        width="w-[min(720px,95vw)]"
+        height="h-auto max-h-[80vh]"
+      >
+        <div className="p-6 space-y-4 text-sm">
+          <p className="text-white/70">Paste snapshot JSON exported from this tool. Import replaces your current stored snapshots.</p>
+          <textarea
+            value={importText}
+            onChange={(e) => setImportText(e.currentTarget.value)}
+            className="w-full min-h-[280px] bg-black/40 border border-white/20 rounded-lg p-3 font-mono text-xs text-white"
+          />
+          {importError && <div className="text-[12px] text-red-300">{importError}</div>}
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={() => { setImportOpen(false); setImportError(null); setImportText(""); }}
+              className="px-3 py-1.5 rounded-md border border-white/20 bg-white/10 text-white/80 hover:bg-white/15"
+            >Cancel</button>
+            <button
+              onClick={() => {
+                try {
+                  const next = importRegSnapshots(importText);
+                  setSnapshots(next);
+                  setImportOpen(false);
+                  setImportText("");
+                  setImportError(null);
+                } catch (err: any) {
+                  setImportError(err?.message || "Failed to import snapshots");
+                }
+              }}
+              className="px-4 py-1.5 rounded-md border border-emerald-300 bg-emerald-500/30 text-emerald-50 hover:bg-emerald-500/40"
+            >Import</button>
+          </div>
+        </div>
+      </ModalDialog>
+    </main>
+  );
+}

--- a/src/components/RegulationResults.tsx
+++ b/src/components/RegulationResults.tsx
@@ -7,6 +7,18 @@ import ModalDialog from "./ModalDialog";
 import OccupancyPrePostPanel from "@/components/OccupancyPrePostPanel";
 import TimeScaleControl from "@/components/TimeScaleControl";
 import { minutesToHHMM } from "@/lib/time";
+import ShimmeringText from "./ShimmeringText";
+import {
+  RegulationSnapshot,
+  loadRegSnapshots,
+  createRegulationSnapshot,
+  addRegSnapshot,
+  MAX_REG_SNAPSHOTS,
+  estimateRegSnapshotsSize,
+  REG_SNAPSHOT_SIZE_WARN_THRESHOLD,
+  RegSnapshotLimitError,
+  REG_SNAPSHOT_STORAGE_KEY,
+} from "@/lib/reg-comparison";
 
 interface RegulationResultsProps {
   open: boolean;
@@ -53,6 +65,38 @@ export default function RegulationResults({ open, result, onClose }: RegulationR
   const [viewFrom, setViewFrom] = useState<string>("00:00");
   const [viewTo, setViewTo] = useState<string>("23:59");
   const [sortMode, setSortMode] = useState<'total' | 'abs_change' | 'exceedance'>("abs_change");
+  const [regSnapshotPromptOpen, setRegSnapshotPromptOpen] = useState(false);
+  const [regSnapshotDescription, setRegSnapshotDescription] = useState("");
+  const [regSnapshotSaving, setRegSnapshotSaving] = useState(false);
+  const [regSnapshotSaveError, setRegSnapshotSaveError] = useState<string | null>(null);
+  const [regSnapshotReplaceId, setRegSnapshotReplaceId] = useState<string | null>(null);
+  const [regSnapshotList, setRegSnapshotList] = useState<RegulationSnapshot[]>([]);
+  const [regSnapshotToast, setRegSnapshotToast] = useState<{
+    kind: "success" | "warning";
+    message: string;
+    action?: { label: string; href: string };
+  } | null>(null);
+
+  const regSnapshotSizeBytes = useMemo(() => estimateRegSnapshotsSize(regSnapshotList), [regSnapshotList]);
+  const regSnapshotSizeWarn = regSnapshotSizeBytes > REG_SNAPSHOT_SIZE_WARN_THRESHOLD;
+  const regSnapshotSizeDisplayKb = Math.max(0, Math.round(regSnapshotSizeBytes / 1024));
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const current = loadRegSnapshots();
+    setRegSnapshotList(current);
+    const onStorage = (ev: StorageEvent) => {
+      if (ev.key && ev.key !== REG_SNAPSHOT_STORAGE_KEY) return;
+      setRegSnapshotList(loadRegSnapshots());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setRegSnapshotList(loadRegSnapshots());
+  }, [open]);
 
   // Initialize default view window when modal opens based on plan regulations
   useEffect(() => {
@@ -93,16 +137,82 @@ export default function RegulationResults({ open, result, onClose }: RegulationR
     return rows;
   }, [result, flights]);
 
+  const regSnapshotCount = regSnapshotList.length;
+
+  const handleOpenRegSnapshotPrompt = () => {
+    if (!result) return;
+    const current = loadRegSnapshots();
+    setRegSnapshotList(current);
+    const defaultDescription = `Regulation Plan ${current.length + 1}`;
+    setRegSnapshotDescription(defaultDescription);
+    if (current.length >= MAX_REG_SNAPSHOTS) {
+      setRegSnapshotReplaceId(current[0]?.id ?? null);
+    } else {
+      setRegSnapshotReplaceId(null);
+    }
+    setRegSnapshotSaveError(null);
+    setRegSnapshotPromptOpen(true);
+  };
+
+  const handleSaveRegSnapshot = () => {
+    if (!result) return;
+    if (regSnapshotList.length >= MAX_REG_SNAPSHOTS && !regSnapshotReplaceId) {
+      setRegSnapshotSaveError(`You already have ${MAX_REG_SNAPSHOTS} snapshots. Select one to replace or delete an existing snapshot.`);
+      return;
+    }
+    setRegSnapshotSaving(true);
+    setRegSnapshotSaveError(null);
+    try {
+      const description = regSnapshotDescription.trim() || `Regulation Plan ${regSnapshotList.length + 1}`;
+      const snapshot = createRegulationSnapshot({
+        description,
+        result,
+        sourceRoute: "regulations",
+      });
+      const next = addRegSnapshot(snapshot, { replaceId: regSnapshotReplaceId || undefined });
+      setRegSnapshotList(next);
+      setRegSnapshotPromptOpen(false);
+      setRegSnapshotReplaceId(null);
+      setRegSnapshotDescription(`Regulation Plan ${next.length + 1}`);
+      setRegSnapshotToast({
+        kind: "success",
+        message: `Saved "${snapshot.description}" for comparison.`,
+        action: { label: "Open Comparison", href: "/regulation-comparison" },
+      });
+    } catch (err: any) {
+      if (err instanceof RegSnapshotLimitError) {
+        setRegSnapshotSaveError(`Only ${err.limit} snapshots can be stored. Select one to replace or remove an existing snapshot.`);
+      } else {
+        setRegSnapshotSaveError(err?.message || "Failed to save snapshot.");
+      }
+    } finally {
+      setRegSnapshotSaving(false);
+    }
+  };
+
   if (!open || !result) return null;
 
   const ds = result.delay_stats;
 
   return (
-    <ModalDialog open={open} onClose={onClose} title="Simulation Results">
-      <div className="p-6 space-y-6">
+    <>
+      <ModalDialog open={open} onClose={onClose} title="Simulation Results">
+        <div className="p-6 space-y-6">
         {/* Delay stats */}
         <div className="bg-white/5 border border-white/10 rounded-xl p-4">
-          <div className="text-sm uppercase tracking-wider text-gray-300 mb-3">Delay Stats</div>
+          <div className="flex flex-wrap items-center gap-3 mb-3">
+            <div className="text-sm uppercase tracking-wider text-gray-300">Delay Stats</div>
+            <button
+              onClick={handleOpenRegSnapshotPrompt}
+              disabled={regSnapshotSaving}
+              className={`ml-auto px-3 py-1 rounded-lg border text-xs flex items-center gap-2 ${regSnapshotSaving ? 'border-emerald-400/50 bg-emerald-500/20 text-emerald-100' : 'border-emerald-400/70 bg-emerald-500/20 text-emerald-100 hover:bg-emerald-500/25'}`}
+            >
+              {regSnapshotSaving ? <ShimmeringText text="Saving…" /> : "Add to Comparison"}
+              <span className={`px-2 py-0.5 rounded-full text-[11px] border ${regSnapshotSizeWarn ? 'border-amber-300/70 bg-amber-500/20 text-amber-100' : 'border-emerald-300/70 bg-emerald-400/10 text-emerald-100'}`}>
+                {regSnapshotCount}/{MAX_REG_SNAPSHOTS}
+              </span>
+            </button>
+          </div>
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
             <Stat label="Total Delay" value={`${Math.round(ds.total_delay_seconds).toLocaleString()} s`} sub={formatSecondsToHMM(ds.total_delay_seconds)} />
             <Stat label="Mean Delay" value={`${Math.round(ds.mean_delay_seconds).toLocaleString()} s`} sub={formatSecondsToHMM(ds.mean_delay_seconds)} />
@@ -219,8 +329,113 @@ export default function RegulationResults({ open, result, onClose }: RegulationR
           )}
         </div>
         
-      </div>
-    </ModalDialog>
+        </div>
+      </ModalDialog>
+
+      <ModalDialog
+        open={regSnapshotPromptOpen}
+        onClose={() => { if (!regSnapshotSaving) setRegSnapshotPromptOpen(false); }}
+        title="Save Regulation Snapshot"
+        width="w-[min(520px,95vw)]"
+        height="h-auto max-h-[85vh]"
+      >
+        <div className="p-6 space-y-4 text-sm">
+          <p className="text-white/80 text-[13px]">
+            Save rolling-hour occupancy, delay stats, and per-flight delays to compare across regulation plans later.
+          </p>
+          <div className="space-y-2">
+            <label className="block text-white/70 text-[12px] uppercase tracking-[0.08em]">Description</label>
+            <input
+              type="text"
+              value={regSnapshotDescription}
+              onChange={(e) => setRegSnapshotDescription(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !regSnapshotSaving) {
+                  e.preventDefault();
+                  handleSaveRegSnapshot();
+                }
+              }}
+              autoFocus
+              placeholder="e.g., Evening push mitigation"
+              className="w-full px-3 py-2 rounded-md bg-white/10 border border-white/20 text-white focus:border-white/40 outline-none"
+            />
+          </div>
+
+          {regSnapshotCount >= MAX_REG_SNAPSHOTS && (
+            <div className="space-y-2">
+              <div className="text-[12px] text-amber-200">
+                You already have {regSnapshotCount} snapshots. Select one to replace or cancel.
+              </div>
+              <select
+                value={regSnapshotReplaceId ?? ""}
+                onChange={(e) => setRegSnapshotReplaceId(e.currentTarget.value || null)}
+                className="w-full px-3 py-2 rounded-md bg-white/10 border border-white/20 text-white focus:border-white/40 outline-none"
+              >
+                {regSnapshotList.map((snap) => (
+                  <option key={snap.id} value={snap.id}>
+                    {snap.description || "Untitled"} · {new Date(snap.createdAt).toLocaleString()}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <div className="text-[12px] text-white/60">
+            Approximate storage used: ~{regSnapshotSizeDisplayKb} KB (limit {MAX_REG_SNAPSHOTS} snapshots).
+          </div>
+
+          {regSnapshotSaveError && (
+            <div className="text-[12px] text-red-300">{regSnapshotSaveError}</div>
+          )}
+
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <button
+              onClick={() => { if (!regSnapshotSaving) setRegSnapshotPromptOpen(false); }}
+              disabled={regSnapshotSaving}
+              className="px-3 py-1.5 rounded-md border border-white/20 bg-white/5 text-white/80 hover:bg-white/10 text-[13px] disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSaveRegSnapshot}
+              disabled={regSnapshotSaving || (regSnapshotCount >= MAX_REG_SNAPSHOTS && !regSnapshotReplaceId)}
+              className="px-4 py-1.5 rounded-md border border-emerald-300 bg-emerald-500/30 text-emerald-50 hover:bg-emerald-500/40 text-[13px] font-medium disabled:opacity-60"
+            >
+              {regSnapshotSaving ? "Saving…" : "Save Snapshot"}
+            </button>
+          </div>
+        </div>
+      </ModalDialog>
+
+      {regSnapshotToast && (
+        <div
+          className={`fixed bottom-6 right-6 z-50 max-w-sm rounded-xl border px-4 py-3 shadow-lg backdrop-blur-sm flex items-start gap-3 ${regSnapshotToast.kind === 'warning' ? 'bg-amber-500/15 border-amber-300/60 text-amber-100' : 'bg-emerald-500/15 border-emerald-300/60 text-emerald-100'}`}
+        >
+          <div className="flex-1 text-sm">
+            <div>{regSnapshotToast.message}</div>
+            {regSnapshotToast.action && (
+              <a
+                href={regSnapshotToast.action.href}
+                className="mt-1 inline-flex items-center gap-1 text-[12px] underline"
+              >
+                {regSnapshotToast.action.label}
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 12h14"></path>
+                  <path d="M12 5l7 7-7 7"></path>
+                </svg>
+              </a>
+            )}
+          </div>
+          <button
+            onClick={() => setRegSnapshotToast(null)}
+            className="text-[12px] text-white/70 hover:text-white"
+            aria-label="Dismiss notification"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+    </>
   );
 }
 

--- a/src/lib/reg-comparison.ts
+++ b/src/lib/reg-comparison.ts
@@ -1,0 +1,281 @@
+import { RegulationPlanSimulationResponse, RegulationPlanDelayStats } from "@/lib/models";
+
+export const REG_SNAPSHOT_VERSION = 1;
+export const REG_SNAPSHOT_STORAGE_KEY = "cortex.regulationSnapshots";
+export const MAX_REG_SNAPSHOTS = 4;
+export const REG_SNAPSHOT_SIZE_WARN_THRESHOLD = Math.floor(4.5 * 1024 * 1024);
+
+export interface RegulationAggregatedRolling {
+  time_bin_minutes: number;
+  pre_counts?: Record<string, number[]>;
+  post_counts: Record<string, number[]>;
+  capacity?: Record<string, number[]>;
+  tv_ids_order?: string[];
+  timeLabels?: string[];
+}
+
+export interface RegulationSnapshot {
+  version: number;
+  id: string;
+  createdAt: string;
+  description: string;
+  sourceRoute: string;
+  minutesPerBin: number;
+  aggregatedRolling: RegulationAggregatedRolling;
+  delayStats: RegulationPlanDelayStats;
+  delaysMin?: Record<string, number> | null;
+  metadata?: Record<string, any> | null;
+  shareUrl?: string | null;
+}
+
+function cloneSeries(values?: number[] | null): number[] {
+  if (!Array.isArray(values)) return [];
+  return values.map((v) => (Number.isFinite(Number(v)) ? Number(v) : 0));
+}
+
+export function generateRegSnapshotId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `reg-snapshot-${Date.now()}-${Math.round(Math.random() * 1e6)}`;
+}
+
+export function createRegulationSnapshot(params: {
+  description: string;
+  result: RegulationPlanSimulationResponse;
+  sourceRoute?: string;
+  id?: string;
+  createdAt?: string;
+  shareUrl?: string | null;
+}): RegulationSnapshot {
+  const { description, result, sourceRoute = "regulations", id = generateRegSnapshotId(), createdAt = new Date().toISOString(), shareUrl = null } = params;
+
+  const rollingList = Array.isArray(result.rolling_changed_tvs) && result.rolling_changed_tvs.length > 0
+    ? result.rolling_changed_tvs
+    : Array.isArray(result.rolling_top_tvs)
+      ? result.rolling_top_tvs
+      : [];
+
+  const minutesPerBin = Number(result.metadata?.time_bin_minutes ?? 15);
+  const postCounts: Record<string, number[]> = {};
+  const preCounts: Record<string, number[]> = {};
+  const capacity: Record<string, number[]> = {};
+  const tvOrder: string[] = [];
+
+  rollingList.forEach((tv) => {
+    if (!tv) return;
+    const tvId = String(tv.traffic_volume_id ?? "");
+    if (!tvId) return;
+    if (!tvOrder.includes(tvId)) {
+      tvOrder.push(tvId);
+    }
+    postCounts[tvId] = cloneSeries(tv.post_rolling_counts);
+    const preSeries = cloneSeries(tv.pre_rolling_counts);
+    if (preSeries.length > 0) {
+      preCounts[tvId] = preSeries;
+    }
+    const capSeries = cloneSeries(tv.capacity_per_bin);
+    if (capSeries.length > 0) {
+      capacity[tvId] = capSeries;
+    }
+  });
+
+  const aggregatedRolling: RegulationAggregatedRolling = {
+    time_bin_minutes: minutesPerBin,
+    post_counts: postCounts,
+  };
+  if (Object.keys(preCounts).length > 0) aggregatedRolling.pre_counts = preCounts;
+  if (Object.keys(capacity).length > 0) aggregatedRolling.capacity = capacity;
+  if (tvOrder.length > 0) aggregatedRolling.tv_ids_order = tvOrder;
+
+  const delayStats: RegulationPlanDelayStats = {
+    total_delay_seconds: Number(result.delay_stats?.total_delay_seconds ?? 0),
+    mean_delay_seconds: Number(result.delay_stats?.mean_delay_seconds ?? 0),
+    max_delay_seconds: Number(result.delay_stats?.max_delay_seconds ?? 0),
+    min_delay_seconds: Number(result.delay_stats?.min_delay_seconds ?? 0),
+    delayed_flights_count: Number(result.delay_stats?.delayed_flights_count ?? 0),
+    num_flights: Number(result.delay_stats?.num_flights ?? 0),
+  };
+
+  const delaysMinEntries = Object.entries(result.delays_by_flight || {});
+  const delaysMin: Record<string, number> = {};
+  delaysMinEntries.forEach(([flightId, delaySeconds]) => {
+    const seconds = Number(delaySeconds);
+    if (!Number.isFinite(seconds)) return;
+    delaysMin[String(flightId)] = seconds / 60;
+  });
+
+  const snapshot: RegulationSnapshot = {
+    version: REG_SNAPSHOT_VERSION,
+    id,
+    createdAt,
+    description: description.trim() || "Untitled regulation plan",
+    sourceRoute,
+    minutesPerBin,
+    aggregatedRolling,
+    delayStats,
+    delaysMin: Object.keys(delaysMin).length > 0 ? delaysMin : null,
+    metadata: result.metadata ? { ...result.metadata } : null,
+    shareUrl,
+  };
+
+  return snapshot;
+}
+
+function readRegSnapshotsFromStorage(): RegulationSnapshot[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(REG_SNAPSHOT_STORAGE_KEY);
+    if (!raw) return [];
+    const arr = JSON.parse(raw);
+    if (!Array.isArray(arr)) return [];
+    return arr
+      .map((item) => {
+        if (!item || typeof item !== "object") return null;
+        const aggregated = (item as any).aggregatedRolling || {};
+        const sanitizedAggregated: RegulationAggregatedRolling = {
+          time_bin_minutes: Number(aggregated.time_bin_minutes ?? (item as any).minutesPerBin ?? 15),
+          post_counts: aggregated.post_counts && typeof aggregated.post_counts === "object" ? { ...aggregated.post_counts } : {},
+          pre_counts: aggregated.pre_counts && typeof aggregated.pre_counts === "object" ? { ...aggregated.pre_counts } : undefined,
+          capacity: aggregated.capacity && typeof aggregated.capacity === "object" ? { ...aggregated.capacity } : undefined,
+          tv_ids_order: Array.isArray(aggregated.tv_ids_order) ? [...aggregated.tv_ids_order] : undefined,
+          timeLabels: Array.isArray(aggregated.timeLabels) ? [...aggregated.timeLabels] : undefined,
+        };
+        return {
+          ...(item as any),
+          version: typeof (item as any).version === "number" ? (item as any).version : REG_SNAPSHOT_VERSION,
+          aggregatedRolling: sanitizedAggregated,
+        } as RegulationSnapshot;
+      })
+      .filter((item): item is RegulationSnapshot => !!item && !!item.id);
+  } catch (err) {
+    console.warn("Failed to parse regulation snapshots from storage", err);
+    return [];
+  }
+}
+
+function writeRegSnapshotsToStorage(snapshots: RegulationSnapshot[]): void {
+  if (typeof window === "undefined") return;
+  const sanitized = snapshots.map((snap) => ({ ...snap, version: REG_SNAPSHOT_VERSION }));
+  window.localStorage.setItem(REG_SNAPSHOT_STORAGE_KEY, JSON.stringify(sanitized));
+}
+
+export function loadRegSnapshots(): RegulationSnapshot[] {
+  return readRegSnapshotsFromStorage();
+}
+
+export class RegSnapshotLimitError extends Error {
+  limit: number;
+  constructor(limit: number) {
+    super(`Only ${limit} regulation snapshots can be stored for comparison.`);
+    this.name = "RegSnapshotLimitError";
+    this.limit = limit;
+  }
+}
+
+export function addRegSnapshot(
+  snapshot: RegulationSnapshot,
+  opts: { replaceId?: string } = {},
+): RegulationSnapshot[] {
+  const existing = readRegSnapshotsFromStorage();
+  let next: RegulationSnapshot[];
+  if (opts.replaceId) {
+    next = existing.map((s) => (s.id === opts.replaceId ? snapshot : s));
+    if (!existing.some((s) => s.id === opts.replaceId)) {
+      next = [...existing, snapshot];
+    }
+  } else {
+    if (existing.length >= MAX_REG_SNAPSHOTS) {
+      throw new RegSnapshotLimitError(MAX_REG_SNAPSHOTS);
+    }
+    next = [...existing, snapshot];
+  }
+  writeRegSnapshotsToStorage(next);
+  return next;
+}
+
+export function updateRegSnapshotDescription(id: string, description: string): RegulationSnapshot[] {
+  const existing = readRegSnapshotsFromStorage();
+  const next = existing.map((snap) => (snap.id === id ? { ...snap, description } : snap));
+  writeRegSnapshotsToStorage(next);
+  return next;
+}
+
+export function deleteRegSnapshot(id: string): RegulationSnapshot[] {
+  const existing = readRegSnapshotsFromStorage();
+  const next = existing.filter((snap) => snap.id !== id);
+  writeRegSnapshotsToStorage(next);
+  return next;
+}
+
+export function clearRegSnapshots(): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(REG_SNAPSHOT_STORAGE_KEY);
+}
+
+export function reorderRegSnapshots(order: string[]): RegulationSnapshot[] {
+  const existing = readRegSnapshotsFromStorage();
+  const orderMap = new Map(order.map((id, idx) => [id, idx] as const));
+  const sorted = [...existing].sort((a, b) => {
+    const ai = orderMap.has(a.id) ? orderMap.get(a.id)! : Number.MAX_SAFE_INTEGER;
+    const bi = orderMap.has(b.id) ? orderMap.get(b.id)! : Number.MAX_SAFE_INTEGER;
+    if (ai !== bi) return ai - bi;
+    return new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  });
+  writeRegSnapshotsToStorage(sorted);
+  return sorted;
+}
+
+export function estimateRegSnapshotsSize(snapshots?: RegulationSnapshot[]): number {
+  const list = snapshots ?? readRegSnapshotsFromStorage();
+  try {
+    const json = JSON.stringify(list);
+    return json ? json.length : 0;
+  } catch (err) {
+    console.warn("Failed to stringify regulation snapshots for size estimate", err);
+    return 0;
+  }
+}
+
+export function exportRegSnapshots(): string {
+  const snaps = readRegSnapshotsFromStorage();
+  return JSON.stringify(snaps, null, 2);
+}
+
+export function importRegSnapshots(raw: string): RegulationSnapshot[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error("Invalid regulation snapshot JSON");
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error("Snapshot import must be an array");
+  }
+  const sanitized: RegulationSnapshot[] = parsed
+    .map((item: any) => {
+      if (!item || typeof item !== "object") return null;
+      const { id, createdAt, description } = item;
+      if (!id || !description) return null;
+      const aggregated = item.aggregatedRolling || {};
+      return {
+        ...item,
+        version: typeof item.version === "number" ? item.version : REG_SNAPSHOT_VERSION,
+        createdAt: createdAt || new Date().toISOString(),
+        aggregatedRolling: {
+          time_bin_minutes: Number(aggregated.time_bin_minutes ?? item.minutesPerBin ?? 15),
+          post_counts: aggregated.post_counts && typeof aggregated.post_counts === "object" ? { ...aggregated.post_counts } : {},
+          pre_counts: aggregated.pre_counts && typeof aggregated.pre_counts === "object" ? { ...aggregated.pre_counts } : undefined,
+          capacity: aggregated.capacity && typeof aggregated.capacity === "object" ? { ...aggregated.capacity } : undefined,
+          tv_ids_order: Array.isArray(aggregated.tv_ids_order) ? [...aggregated.tv_ids_order] : undefined,
+          timeLabels: Array.isArray(aggregated.timeLabels) ? [...aggregated.timeLabels] : undefined,
+        },
+      } as RegulationSnapshot;
+    })
+    .filter(Boolean) as RegulationSnapshot[];
+  if (sanitized.length > MAX_REG_SNAPSHOTS) {
+    throw new RegSnapshotLimitError(MAX_REG_SNAPSHOTS);
+  }
+  writeRegSnapshotsToStorage(sanitized);
+  return sanitized;
+}


### PR DESCRIPTION
## Summary
- add a dedicated regulation snapshot storage module for saving rolling occupancy, delays, and metadata
- extend the regulation results modal with an Add to Comparison flow, description prompt, and toast
- implement the regulation comparison page with snapshot management, delay cards, flight table, and occupancy charts

## Testing
- npm run lint *(fails: existing lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68ca7caa0378832bb1c1402820012792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a Regulation Comparison dashboard to manage and compare saved regulation snapshots.
  - Save snapshots from results via “Add to Comparison,” with live counter, toasts, and storage usage warnings.
  - Import/export snapshots as JSON; rename, delete, reorder, or replace when at capacity.
  - Delay analytics: per-snapshot totals/means; flight delay table with filtering, sorting, and time-window control.
  - Traffic Volume occupancy charts with filtering, legends, and “Show more.”
  - Requires login; data persists locally and syncs across tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->