### PR TITLE
Add side panel minimization controls

### DIFF
--- a/src/app/flows/page.tsx
+++ b/src/app/flows/page.tsx
@@ -12,10 +12,15 @@ import Header from "@/components/Header";
 import StateResetOnPageLoad from "@/components/StateResetOnPageLoad";
 import ViewOptionsControl from "@/components/ViewOptionsControl";
 
+const LEFT_PANEL_WIDTH = 360;
+const RIGHT_PANEL_GROUP_WIDTH = 384 + 340 + 16;
+
 export default function FlowsPage() {
   const router = useRouter();
   const user = useSimStore((state) => state.user);
   const [hydrated, setHydrated] = useState(false);
+  const [leftPanelsMinimized, setLeftPanelsMinimized] = useState(false);
+  const [rightPanelsMinimized, setRightPanelsMinimized] = useState(false);
 
   useEffect(() => {
     const unsub = useSimStore.persist.onFinishHydration(() => setHydrated(true));
@@ -40,25 +45,56 @@ export default function FlowsPage() {
       <StateResetOnPageLoad />
       <Header />
       <FlowCanvas />
+      <button
+        type="button"
+        aria-label={leftPanelsMinimized ? "Expand left panels" : "Collapse left panels"}
+        title={leftPanelsMinimized ? "Expand left panels" : "Collapse left panels"}
+        onClick={() => setLeftPanelsMinimized((prev) => !prev)}
+        style={{ left: leftPanelsMinimized ? "0.75rem" : `calc(${LEFT_PANEL_WIDTH}px + 1.5rem)` }}
+        className="absolute top-1/2 -translate-y-1/2 z-50 w-9 h-9 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-white/80 hover:text-white hover:bg-white/20 transition-all duration-300 ease-in-out shadow-lg flex items-center justify-center"
+      >
+        <span className="text-lg font-semibold leading-none">
+          {leftPanelsMinimized ? ">" : "<"}
+        </span>
+      </button>
+      <button
+        type="button"
+        aria-label={rightPanelsMinimized ? "Expand right panels" : "Collapse right panels"}
+        title={rightPanelsMinimized ? "Expand right panels" : "Collapse right panels"}
+        onClick={() => setRightPanelsMinimized((prev) => !prev)}
+        style={{ right: rightPanelsMinimized ? "0.75rem" : `calc(${RIGHT_PANEL_GROUP_WIDTH}px + 1.5rem)` }}
+        className="absolute top-1/2 -translate-y-1/2 z-50 w-9 h-9 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-white/80 hover:text-white hover:bg-white/20 transition-all duration-300 ease-in-out shadow-lg flex items-center justify-center"
+      >
+        <span className="text-lg font-semibold leading-none">
+          {rightPanelsMinimized ? "<" : ">"}
+        </span>
+      </button>
       {/* Left-side wrapper: full-height scroll; panels take natural height */}
-      <div className="absolute top-0 left-4 z-40 w-[360px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
+      <div
+        style={{ transform: leftPanelsMinimized ? "translateX(calc(-100% - 1.5rem))" : "translateX(0)" }}
+        className={`absolute top-0 left-4 z-40 w-[360px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none transition-all duration-300 ease-in-out ${leftPanelsMinimized ? "opacity-0" : "opacity-100"}`}
+      >
         <div className="pointer-events-auto">
           <LeftControl1Flow embedded />
         </div>
       </div>
-      {/* Right-side wrapper for Regulation + Flow panels (full-height, below header) */}
-      <div className="right-side-wrapper absolute top-0 right-4 z-40 w-[384px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
-        <div className="pointer-events-auto">
-          <FlowRegulationPanel embedded />
+      {/* Right-side wrapper group */}
+      <div
+        style={{ transform: rightPanelsMinimized ? "translateX(calc(100% + 1.5rem))" : "translateX(0)" }}
+        className={`absolute top-0 right-4 z-40 h-screen min-h-0 pointer-events-none flex gap-4 transition-all duration-300 ease-in-out ${rightPanelsMinimized ? "opacity-0" : "opacity-100"}`}
+      >
+        <div className="w-[340px] h-full min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
+          <div className="pointer-events-auto">
+            <FlowPlanPanel embedded />
+          </div>
         </div>
-        <div className="pointer-events-auto">
-          <FlowAirspaceView embedded />
-        </div>
-      </div>
-      {/* Left of right-side wrapper: full-height scroll container for FlowPlanPanel */}
-      <div className="absolute top-0 right-[416px] z-40 w-[340px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
-        <div className="pointer-events-auto">
-          <FlowPlanPanel embedded />
+        <div className="w-[384px] h-full min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
+          <div className="pointer-events-auto">
+            <FlowRegulationPanel embedded />
+          </div>
+          <div className="pointer-events-auto">
+            <FlowAirspaceView embedded />
+          </div>
         </div>
       </div>
       <ViewOptionsControl />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,6 +28,8 @@ function countTimesUpTo(sortedTimes: number[], value: number): number {
 }
 
 const DAY_SECONDS = 24 * 60 * 60;
+const LEFT_PANEL_WIDTH = 360;
+const RIGHT_PANEL_WIDTH = 384;
 
 export default function Page() {
   const router = useRouter();
@@ -35,6 +37,8 @@ export default function Page() {
   const flights = useSimStore((state) => state.flights);
   const t = useSimStore((state) => state.t);
   const [hydrated, setHydrated] = useState(false);
+  const [leftPanelsMinimized, setLeftPanelsMinimized] = useState(false);
+  const [rightPanelsMinimized, setRightPanelsMinimized] = useState(false);
 
   const sortedStartTimes = useMemo(() => {
     if (!flights || flights.length === 0) {
@@ -110,8 +114,35 @@ export default function Page() {
       <StateResetOnPageLoad />
       <Header />
       <MapCanvas />
+      <button
+        type="button"
+        aria-label={leftPanelsMinimized ? "Expand left panels" : "Collapse left panels"}
+        title={leftPanelsMinimized ? "Expand left panels" : "Collapse left panels"}
+        onClick={() => setLeftPanelsMinimized((prev) => !prev)}
+        style={{ left: leftPanelsMinimized ? "0.75rem" : `calc(${LEFT_PANEL_WIDTH}px + 1.5rem)` }}
+        className="absolute top-1/2 -translate-y-1/2 z-50 w-9 h-9 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-white/80 hover:text-white hover:bg-white/20 transition-all duration-300 ease-in-out shadow-lg flex items-center justify-center"
+      >
+        <span className="text-lg font-semibold leading-none">
+          {leftPanelsMinimized ? ">" : "<"}
+        </span>
+      </button>
+      <button
+        type="button"
+        aria-label={rightPanelsMinimized ? "Expand right panels" : "Collapse right panels"}
+        title={rightPanelsMinimized ? "Expand right panels" : "Collapse right panels"}
+        onClick={() => setRightPanelsMinimized((prev) => !prev)}
+        style={{ right: rightPanelsMinimized ? "0.75rem" : `calc(${RIGHT_PANEL_WIDTH}px + 1.5rem)` }}
+        className="absolute top-1/2 -translate-y-1/2 z-50 w-9 h-9 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-white/80 hover:text-white hover:bg-white/20 transition-all duration-300 ease-in-out shadow-lg flex items-center justify-center"
+      >
+        <span className="text-lg font-semibold leading-none">
+          {rightPanelsMinimized ? "<" : ">"}
+        </span>
+      </button>
       {/* Left-side wrapper: full-height, scrolls; panel inside does not */}
-      <div className="absolute top-0 left-4 z-40 w-[360px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4">
+      <div
+        style={{ transform: leftPanelsMinimized ? "translateX(calc(-100% - 1.5rem))" : "translateX(0)" }}
+        className={`absolute top-0 left-4 z-40 w-[360px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 transition-all duration-300 ease-in-out ${leftPanelsMinimized ? "opacity-0 pointer-events-none" : "opacity-100"}`}
+      >
         <LeftControl1 embedded />
         <NetworkStatusPanel
           embedded
@@ -121,7 +152,10 @@ export default function Page() {
         />
       </div>
       {/* Right-side wrapper: full-height scroll for the panel */}
-      <div className="absolute top-0 right-4 z-40 w-[384px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
+      <div
+        style={{ transform: rightPanelsMinimized ? "translateX(calc(100% + 1.5rem))" : "translateX(0)" }}
+        className={`absolute top-0 right-4 z-40 w-[384px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none transition-all duration-300 ease-in-out ${rightPanelsMinimized ? "opacity-0" : "opacity-100"}`}
+      >
         <div className="pointer-events-auto">
           <RightControl1 embedded />
         </div>

--- a/src/app/regulations/page.tsx
+++ b/src/app/regulations/page.tsx
@@ -12,10 +12,15 @@ import StateResetOnPageLoad from "@/components/StateResetOnPageLoad";
 import ViewOptionsControl from "@/components/ViewOptionsControl";
 import SlackViewControl from "@/components/SlackViewControl";
 
+const LEFT_PANEL_WIDTH = 360;
+const RIGHT_PANEL_WIDTH = 384;
+
 export default function RegulationsPage() {
   const router = useRouter();
   const user = useSimStore((state) => state.user);
   const [hydrated, setHydrated] = useState(false);
+  const [leftPanelsMinimized, setLeftPanelsMinimized] = useState(false);
+  const [rightPanelsMinimized, setRightPanelsMinimized] = useState(false);
 
   useEffect(() => {
     const unsub = useSimStore.persist.onFinishHydration(() => setHydrated(true));
@@ -40,8 +45,35 @@ export default function RegulationsPage() {
       <StateResetOnPageLoad />
       <Header />
       <RegulationCanvas />
+      <button
+        type="button"
+        aria-label={leftPanelsMinimized ? "Expand left panels" : "Collapse left panels"}
+        title={leftPanelsMinimized ? "Expand left panels" : "Collapse left panels"}
+        onClick={() => setLeftPanelsMinimized((prev) => !prev)}
+        style={{ left: leftPanelsMinimized ? "0.75rem" : `calc(${LEFT_PANEL_WIDTH}px + 1.5rem)` }}
+        className="absolute top-1/2 -translate-y-1/2 z-50 w-9 h-9 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-white/80 hover:text-white hover:bg-white/20 transition-all duration-300 ease-in-out shadow-lg flex items-center justify-center"
+      >
+        <span className="text-lg font-semibold leading-none">
+          {leftPanelsMinimized ? ">" : "<"}
+        </span>
+      </button>
+      <button
+        type="button"
+        aria-label={rightPanelsMinimized ? "Expand right panels" : "Collapse right panels"}
+        title={rightPanelsMinimized ? "Expand right panels" : "Collapse right panels"}
+        onClick={() => setRightPanelsMinimized((prev) => !prev)}
+        style={{ right: rightPanelsMinimized ? "0.75rem" : `calc(${RIGHT_PANEL_WIDTH}px + 1.5rem)` }}
+        className="absolute top-1/2 -translate-y-1/2 z-50 w-9 h-9 rounded-full border border-white/20 bg-white/10 backdrop-blur-md text-white/80 hover:text-white hover:bg-white/20 transition-all duration-300 ease-in-out shadow-lg flex items-center justify-center"
+      >
+        <span className="text-lg font-semibold leading-none">
+          {rightPanelsMinimized ? "<" : ">"}
+        </span>
+      </button>
       {/* Left-side wrapper: full-height scroll; panels take natural height */}
-      <div className="absolute top-0 left-4 z-40 w-[360px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
+      <div
+        style={{ transform: leftPanelsMinimized ? "translateX(calc(-100% - 1.5rem))" : "translateX(0)" }}
+        className={`absolute top-0 left-4 z-40 w-[360px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none transition-all duration-300 ease-in-out ${leftPanelsMinimized ? "opacity-0" : "opacity-100"}`}
+      >
         <div className="pointer-events-auto">
           <LeftControl1Regulation embedded />
         </div>
@@ -50,7 +82,10 @@ export default function RegulationsPage() {
         </div>
       </div>
       {/* Right-side wrapper: full-height scroll for the panel */}
-      <div className="absolute top-0 right-4 z-40 w-[384px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
+      <div
+        style={{ transform: rightPanelsMinimized ? "translateX(calc(100% + 1.5rem))" : "translateX(0)" }}
+        className={`absolute top-0 right-4 z-40 w-[384px] h-screen min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none transition-all duration-300 ease-in-out ${rightPanelsMinimized ? "opacity-0" : "opacity-100"}`}
+      >
         <div className="pointer-events-auto">
           <RegulationPanel embedded />
         </div>


### PR DESCRIPTION
## Summary
- add floating chevron controls to collapse or restore the left and right panel stacks on the main, regulations, and flows pages
- animate the panel wrapper visibility and pointer interactivity when minimized to keep the map unobstructed
- regroup the flows page right-side panels so they minimize together with the new control

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68caa2d20c6c832b95dd8b35d977eda4