### PR TITLE
Fix spinner styling for dark mode

### DIFF
--- a/src/components/AirspaceInfo.tsx
+++ b/src/components/AirspaceInfo.tsx
@@ -518,7 +518,7 @@ export default function AirspaceInfo() {
 
           {loading && (
             <div className="flex items-center justify-center py-8">
-              <div className="animate-spin rounded-full h-6 w-6 border-2 border-white/20 border-t-white"></div>
+              <div className="animate-spin rounded-full h-6 w-6 border-2 border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
               <span className="ml-2 text-sm opacity-70">Loading...</span>
             </div>
           )}
@@ -635,7 +635,7 @@ export default function AirspaceInfo() {
             
             {flightListLoading && (
               <div className="flex items-center justify-center py-4">
-                <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white"></div>
+                <div className="animate-spin rounded-full h-4 w-4 border-2 border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
                 <span className="ml-2 text-xs opacity-70">Loading flights...</span>
               </div>
             )}

--- a/src/components/FlowAirspaceView.tsx
+++ b/src/components/FlowAirspaceView.tsx
@@ -596,7 +596,7 @@ export default function FlowAirspaceView({ embedded = false }: FlowAirspaceViewP
 
           {flightListLoading && (
             <div className="flex items-center justify-center py-4">
-              <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white"></div>
+              <div className="animate-spin rounded-full h-4 w-4 border-2 border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
               <span className="ml-2 text-xs opacity-70">Loading flights...</span>
             </div>
           )}

--- a/src/components/LeftControl1.tsx
+++ b/src/components/LeftControl1.tsx
@@ -162,7 +162,7 @@ export default function LeftControl1({ embedded = false }: LeftControl1Props) {
               <h4 className="font-medium text-sm opacity-90">Hotspots</h4>
               {hotspotsLoading && (
                 <div className="flex items-center">
-                  <div className="animate-spin rounded-full h-3 w-3 border border-white/20 border-t-white"></div>
+                  <div className="animate-spin rounded-full h-3 w-3 border border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
                   <ShimmeringText text="Loading..." className="ml-1 text-xs opacity-70" />
                 </div>
               )}

--- a/src/components/LeftControl1Flow.tsx
+++ b/src/components/LeftControl1Flow.tsx
@@ -156,7 +156,7 @@ export default function LeftControl1Flow({ embedded = false }: LeftControl1FlowP
               <h4 className="font-medium text-sm opacity-90">Hotspots</h4>
               {hotspotsLoading && (
                 <div className="flex items-center">
-                  <div className="animate-spin rounded-full h-3 w-3 border border-white/20 border-t-white"></div>
+                  <div className="animate-spin rounded-full h-3 w-3 border border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
                   <ShimmeringText text="Loading..." className="ml-1 text-xs opacity-70" />
                 </div>
               )}

--- a/src/components/LeftControl1Regulation.tsx
+++ b/src/components/LeftControl1Regulation.tsx
@@ -156,7 +156,7 @@ export default function LeftControl1Regulation({ embedded = false }: LeftControl
               <h4 className="font-medium text-sm opacity-90">Hotspots</h4>
               {hotspotsLoading && (
                 <div className="flex items-center">
-                  <div className="animate-spin rounded-full h-3 w-3 border border-white/20 border-t-white"></div>
+                  <div className="animate-spin rounded-full h-3 w-3 border border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
                   <ShimmeringText text="Loading..." className="ml-1 text-xs opacity-70" />
                 </div>
               )}

--- a/src/components/PageLoadingIndicator.tsx
+++ b/src/components/PageLoadingIndicator.tsx
@@ -12,7 +12,7 @@ export default function PageLoadingIndicator({ visible = false, text = "Sweeping
   return (
     <div className="absolute inset-0 z-50 flex items-center justify-center">
       <div className="flex items-center rounded-xl bg-white/10 backdrop-blur-md border border-white/30 px-3 py-2 shadow-lg">
-        <div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white"></div>
+        <div className="animate-spin rounded-full h-4 w-4 border-2 border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
         <ShimmeringText text={text} className="ml-2 text-sm opacity-80" />
       </div>
     </div>

--- a/src/components/RegulationFlightListLeftPanel2.tsx
+++ b/src/components/RegulationFlightListLeftPanel2.tsx
@@ -169,7 +169,7 @@ export default function RegulationFlightListLeftPanel2({ embedded = false }: Reg
 				)}
 				{loading ? (
 					<div className="flex items-center justify-center py-4">
-						<div className="animate-spin rounded-full h-4 w-4 border-2 border-white/20 border-t-white"></div>
+                                                <div className="animate-spin rounded-full h-4 w-4 border-2 border-[color:var(--panel-border)] border-t-[color:var(--panel-text-primary)]"></div>
 						<ShimmeringText text="Loading..." className="ml-2 text-xs opacity-70" />
 					</div>
 				) : error ? (


### PR DESCRIPTION
## Summary
- update loading spinners to use theme-driven border colors so the animation remains visible in dark mode

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb09c68d78832b8cdf8ab4a2c19219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated all loading spinners to use theme-aware colors for better consistency across light/dark modes.
  - Applied the new styling to spinners in airspace views, flow views, hotspots panels, regulation panels, and the page loading indicator.
  - Visual-only change; no impact on behavior or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->