### PR TITLE
Hide traffic volume layers when flight level range is empty

### DIFF
--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -11,6 +11,8 @@ import PageLoadingIndicator from "@/components/PageLoadingIndicator";
 import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
 import { createMapStyle } from "@/lib/mapStyle";
 
+const createHideAllFilter = () => ["==", 1, 0] as any;
+
 export default function FlowCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
   const rafRef = useRef<number | undefined>(undefined);
@@ -323,22 +325,30 @@ export default function FlowCanvas() {
   // on FL range change, filter traffic volumes
   useEffect(() => {
     if (mapRef.current && mapRef.current.getSource("sectors")) {
-      const filterExpression: any = [
-        "all",
-        [">=", ["get", "max_fl"], flLowerBound],
-        ["<=", ["get", "min_fl"], flUpperBound]
-      ];
+      const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+      const hiddenFilter = createHideAllFilter();
+      const filterExpression: any = shouldHideTrafficVolumes
+        ? hiddenFilter
+        : [
+            "all",
+            [">=", ["get", "max_fl"], flLowerBound],
+            ["<=", ["get", "min_fl"], flUpperBound]
+          ];
       if (mapRef.current.getLayer("sector-fill")) mapRef.current.setFilter("sector-fill", filterExpression);
       if (mapRef.current.getLayer("sector-outline")) mapRef.current.setFilter("sector-outline", filterExpression);
       if (mapRef.current.getLayer("sector-labels")) mapRef.current.setFilter("sector-labels", filterExpression);
       // (Slack layer removed) no sector-slack filter
       // Ensure highlight and hover layers are also absolutely filtered by FL range
-      const hlFilter: any = highlightedTrafficVolume
-        ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-        : ["==", ["get", "traffic_volume_id"], ""];
-      const hvFilter: any = hoveredTrafficVolume
-        ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-        : ["==", ["get", "traffic_volume_id"], ""];
+      const hlFilter: any = shouldHideTrafficVolumes
+        ? hiddenFilter
+        : highlightedTrafficVolume
+          ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+          : hiddenFilter;
+      const hvFilter: any = shouldHideTrafficVolumes
+        ? hiddenFilter
+        : hoveredTrafficVolume
+          ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+          : hiddenFilter;
       if (mapRef.current.getLayer("sector-highlight")) mapRef.current.setFilter("sector-highlight", hlFilter as any);
       if (mapRef.current.getLayer("sector-highlight-outline")) mapRef.current.setFilter("sector-highlight-outline", hlFilter as any);
       if (mapRef.current.getLayer("sector-hover")) mapRef.current.setFilter("sector-hover", hvFilter as any);
@@ -349,30 +359,39 @@ export default function FlowCanvas() {
   // Update highlight/hover layers when state changes
   useEffect(() => {
     if (!mapRef.current) return;
-    const highlightFilter = highlightedTrafficVolume
-      ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-      : ["==", ["get", "traffic_volume_id"], ""];
+    const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+    const highlightFilter = shouldHideTrafficVolumes
+      ? createHideAllFilter()
+      : highlightedTrafficVolume
+        ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+        : createHideAllFilter();
     if (mapRef.current.getLayer("sector-highlight")) mapRef.current.setFilter("sector-highlight", highlightFilter as any);
     if (mapRef.current.getLayer("sector-highlight-outline")) mapRef.current.setFilter("sector-highlight-outline", highlightFilter as any);
-  }, [highlightedTrafficVolume]);
+  }, [highlightedTrafficVolume, flLowerBound, flUpperBound]);
 
   useEffect(() => {
     if (!mapRef.current) return;
-    const hoverFilter = hoveredTrafficVolume
-      ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-      : ["==", ["get", "traffic_volume_id"], ""];
+    const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+    const hoverFilter = shouldHideTrafficVolumes
+      ? createHideAllFilter()
+      : hoveredTrafficVolume
+        ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+        : createHideAllFilter();
     if (mapRef.current.getLayer("sector-hover")) mapRef.current.setFilter("sector-hover", hoverFilter as any);
     if (mapRef.current.getLayer("sector-hover-outline")) mapRef.current.setFilter("sector-hover-outline", hoverFilter as any);
-  }, [hoveredTrafficVolume]);
+  }, [hoveredTrafficVolume, flLowerBound, flUpperBound]);
 
   // Update hotspot layers when hotspots/time/FL range changes
   useEffect(() => {
     if (!mapRef.current) return;
     const activeHotspots = getActiveHotspots();
     const hotspotTrafficVolumeIds = activeHotspots.map(h => h.traffic_volume_id);
-    const hotspotFilter = hotspotTrafficVolumeIds.length > 0 
-      ? [ "all", ["in", ["get", "traffic_volume_id"], ["literal", hotspotTrafficVolumeIds]], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound] ]
-      : ["==", ["get", "traffic_volume_id"], ""];
+    const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+    const hotspotFilter = shouldHideTrafficVolumes
+      ? createHideAllFilter()
+      : hotspotTrafficVolumeIds.length > 0
+        ? [ "all", ["in", ["get", "traffic_volume_id"], ["literal", hotspotTrafficVolumeIds]], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound] ]
+        : createHideAllFilter();
     if (mapRef.current.getLayer("sector-hotspot")) mapRef.current.setFilter("sector-hotspot", hotspotFilter as any);
     if (mapRef.current.getLayer("sector-hotspot-outline")) mapRef.current.setFilter("sector-hotspot-outline", hotspotFilter as any);
   }, [showHotspots, hotspots, flLowerBound, flUpperBound, t, getActiveHotspots]);

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -14,6 +14,8 @@ import PageLoadingIndicator from "@/components/PageLoadingIndicator";
 import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
 import { createMapStyle } from "@/lib/mapStyle";
 
+const createHideAllFilter = () => ["==", 1, 0] as any;
+
 export default function MapCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
   const rafRef = useRef<number | undefined>(undefined);
@@ -588,13 +590,14 @@ export default function MapCanvas() {
   // on FL range change, filter traffic volumes based on vertical intersection
   useEffect(() => {
     if (mapRef.current && mapRef.current.getSource("sectors")) {
-      // Create filter expression to show only sectors that intersect with FL range
-      // A sector intersects if: max_fl >= flLowerBound AND min_fl <= flUpperBound
-      const filterExpression: any = [
-        "all",
-        [">=", ["get", "max_fl"], flLowerBound],
-        ["<=", ["get", "min_fl"], flUpperBound]
-      ];
+      const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+      const filterExpression: any = shouldHideTrafficVolumes
+        ? createHideAllFilter()
+        : [
+            "all",
+            [">=", ["get", "max_fl"], flLowerBound],
+            ["<=", ["get", "min_fl"], flUpperBound]
+          ];
 
       if (mapRef.current.getLayer("sector-fill")) {
         mapRef.current.setFilter("sector-fill", filterExpression);
@@ -616,9 +619,12 @@ export default function MapCanvas() {
   // Update highlight layer when highlighted traffic volume changes
   useEffect(() => {
     if (mapRef.current) {
-      const highlightFilter = highlightedTrafficVolume 
-        ? ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume]
-        : ["==", ["get", "traffic_volume_id"], ""];
+      const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+      const highlightFilter = shouldHideTrafficVolumes
+        ? createHideAllFilter()
+        : highlightedTrafficVolume
+          ? ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume]
+          : ["==", ["get", "traffic_volume_id"], ""];
 
       if (mapRef.current.getLayer("sector-highlight")) {
         mapRef.current.setFilter("sector-highlight", highlightFilter as any);
@@ -627,14 +633,17 @@ export default function MapCanvas() {
         mapRef.current.setFilter("sector-highlight-outline", highlightFilter as any);
       }
     }
-  }, [highlightedTrafficVolume]);
+  }, [highlightedTrafficVolume, flLowerBound, flUpperBound]);
 
   // Update hover layer when hovered traffic volume changes
   useEffect(() => {
     if (mapRef.current) {
-      const hoverFilter = hoveredTrafficVolume 
-        ? ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume]
-        : ["==", ["get", "traffic_volume_id"], ""];
+      const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+      const hoverFilter = shouldHideTrafficVolumes
+        ? createHideAllFilter()
+        : hoveredTrafficVolume
+          ? ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume]
+          : ["==", ["get", "traffic_volume_id"], ""];
 
       if (mapRef.current.getLayer("sector-hover")) {
         mapRef.current.setFilter("sector-hover", hoverFilter as any);
@@ -643,7 +652,7 @@ export default function MapCanvas() {
         mapRef.current.setFilter("sector-hover-outline", hoverFilter as any);
       }
     }
-  }, [hoveredTrafficVolume]);
+  }, [hoveredTrafficVolume, flLowerBound, flUpperBound]);
 
   // Update hotspot layers when hotspots change, FL range changes, or time changes
   useEffect(() => {
@@ -652,14 +661,17 @@ export default function MapCanvas() {
       const activeHotspots = getActiveHotspots();
       const hotspotTrafficVolumeIds = activeHotspots.map(h => h.traffic_volume_id);
       
-      const hotspotFilter = hotspotTrafficVolumeIds.length > 0 
-        ? [
-            "all",
-            ["in", ["get", "traffic_volume_id"], ["literal", hotspotTrafficVolumeIds]],
-            [">=", ["get", "max_fl"], flLowerBound],
-            ["<=", ["get", "min_fl"], flUpperBound]
-          ]
-        : ["==", ["get", "traffic_volume_id"], ""];
+      const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+      const hotspotFilter = shouldHideTrafficVolumes
+        ? createHideAllFilter()
+        : hotspotTrafficVolumeIds.length > 0
+          ? [
+              "all",
+              ["in", ["get", "traffic_volume_id"], ["literal", hotspotTrafficVolumeIds]],
+              [">=", ["get", "max_fl"], flLowerBound],
+              ["<=", ["get", "min_fl"], flUpperBound]
+            ]
+          : ["==", ["get", "traffic_volume_id"], ""];
 
       if (mapRef.current.getLayer("sector-hotspot")) {
         mapRef.current.setFilter("sector-hotspot", hotspotFilter as any);

--- a/src/components/RegulationCanvas.tsx
+++ b/src/components/RegulationCanvas.tsx
@@ -14,6 +14,8 @@ import PageLoadingIndicator from "@/components/PageLoadingIndicator";
 import { ensureSurfacePrecipHour, hideSurfacePrecipLayer, isoHourFrom } from "@/lib/weatherOverlay";
 import { createMapStyle } from "@/lib/mapStyle";
 
+const createHideAllFilter = () => ["==", 1, 0] as any;
+
 export default function RegulationCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
   const rafRef = useRef<number | undefined>(undefined);
@@ -365,22 +367,30 @@ export default function RegulationCanvas() {
   // on FL range change, filter traffic volumes
   useEffect(() => {
     if (mapRef.current && mapRef.current.getSource("sectors")) {
-      const filterExpression: any = [
-        "all",
-        [">=", ["get", "max_fl"], flLowerBound],
-        ["<=", ["get", "min_fl"], flUpperBound]
-      ];
+      const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+      const hiddenFilter = createHideAllFilter();
+      const filterExpression: any = shouldHideTrafficVolumes
+        ? hiddenFilter
+        : [
+            "all",
+            [">=", ["get", "max_fl"], flLowerBound],
+            ["<=", ["get", "min_fl"], flUpperBound]
+          ];
       if (mapRef.current.getLayer("sector-fill")) mapRef.current.setFilter("sector-fill", filterExpression);
       if (mapRef.current.getLayer("sector-outline")) mapRef.current.setFilter("sector-outline", filterExpression);
       if (mapRef.current.getLayer("sector-labels")) mapRef.current.setFilter("sector-labels", filterExpression);
       if (mapRef.current.getLayer("sector-slack")) mapRef.current.setFilter("sector-slack", filterExpression);
       // Ensure highlight and hover layers are also absolutely filtered by FL range
-      const hlFilter: any = highlightedTrafficVolume
-        ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-        : ["==", ["get", "traffic_volume_id"], ""];
-      const hvFilter: any = hoveredTrafficVolume
-        ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-        : ["==", ["get", "traffic_volume_id"], ""];
+      const hlFilter: any = shouldHideTrafficVolumes
+        ? hiddenFilter
+        : highlightedTrafficVolume
+          ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+          : hiddenFilter;
+      const hvFilter: any = shouldHideTrafficVolumes
+        ? hiddenFilter
+        : hoveredTrafficVolume
+          ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+          : hiddenFilter;
       if (mapRef.current.getLayer("sector-highlight")) mapRef.current.setFilter("sector-highlight", hlFilter as any);
       if (mapRef.current.getLayer("sector-highlight-outline")) mapRef.current.setFilter("sector-highlight-outline", hlFilter as any);
       if (mapRef.current.getLayer("sector-hover")) mapRef.current.setFilter("sector-hover", hvFilter as any);
@@ -391,18 +401,24 @@ export default function RegulationCanvas() {
   // Update highlight/hover layers when state changes
   useEffect(() => {
     if (!mapRef.current) return;
-    const highlightFilter = highlightedTrafficVolume
-      ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-      : ["==", ["get", "traffic_volume_id"], ""];
+    const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+    const highlightFilter = shouldHideTrafficVolumes
+      ? createHideAllFilter()
+      : highlightedTrafficVolume
+        ? ["all", ["==", ["get", "traffic_volume_id"], highlightedTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+        : createHideAllFilter();
     if (mapRef.current.getLayer("sector-highlight")) mapRef.current.setFilter("sector-highlight", highlightFilter as any);
     if (mapRef.current.getLayer("sector-highlight-outline")) mapRef.current.setFilter("sector-highlight-outline", highlightFilter as any);
   }, [highlightedTrafficVolume, flLowerBound, flUpperBound]);
 
   useEffect(() => {
     if (!mapRef.current) return;
-    const hoverFilter = hoveredTrafficVolume
-      ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
-      : ["==", ["get", "traffic_volume_id"], ""];
+    const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+    const hoverFilter = shouldHideTrafficVolumes
+      ? createHideAllFilter()
+      : hoveredTrafficVolume
+        ? ["all", ["==", ["get", "traffic_volume_id"], hoveredTrafficVolume], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound]]
+        : createHideAllFilter();
     if (mapRef.current.getLayer("sector-hover")) mapRef.current.setFilter("sector-hover", hoverFilter as any);
     if (mapRef.current.getLayer("sector-hover-outline")) mapRef.current.setFilter("sector-hover-outline", hoverFilter as any);
   }, [hoveredTrafficVolume, flLowerBound, flUpperBound]);
@@ -412,9 +428,12 @@ export default function RegulationCanvas() {
     if (!mapRef.current) return;
     const activeHotspots = getActiveHotspots();
     const hotspotTrafficVolumeIds = activeHotspots.map(h => h.traffic_volume_id);
-    const hotspotFilter = hotspotTrafficVolumeIds.length > 0 
-      ? [ "all", ["in", ["get", "traffic_volume_id"], ["literal", hotspotTrafficVolumeIds]], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound] ]
-      : ["==", ["get", "traffic_volume_id"], ""];
+    const shouldHideTrafficVolumes = flUpperBound <= flLowerBound;
+    const hotspotFilter = shouldHideTrafficVolumes
+      ? createHideAllFilter()
+      : hotspotTrafficVolumeIds.length > 0
+        ? [ "all", ["in", ["get", "traffic_volume_id"], ["literal", hotspotTrafficVolumeIds]], [">=", ["get", "max_fl"], flLowerBound], ["<=", ["get", "min_fl"], flUpperBound] ]
+        : createHideAllFilter();
     if (mapRef.current.getLayer("sector-hotspot")) mapRef.current.setFilter("sector-hotspot", hotspotFilter as any);
     if (mapRef.current.getLayer("sector-hotspot-outline")) mapRef.current.setFilter("sector-hotspot-outline", hotspotFilter as any);
   }, [showHotspots, hotspots, flLowerBound, flUpperBound, t, getActiveHotspots]);


### PR DESCRIPTION
## Summary
- hide traffic volume layers in the base map, regulation, and flow canvases when the selected flight level range collapses
- make highlight, hover, and hotspot filters respect the zero-width flight level range so no traffic volume geometry is rendered

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb0d675a34832ba4be516f79b25dec