### PR TITLE
Add traffic volume visibility toggle

### DIFF
--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -16,7 +16,7 @@ export default function FlowCanvas() {
   const rafRef = useRef<number | undefined>(undefined);
   const lastTs = useRef<number>(performance.now());
   const lastUpdateRef = useRef<number>(performance.now());
-  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, flowViewEnabled, flowCommunities, flowGroups, flowPreviewGroupId, flowPreviewFlightId, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
+  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showTrafficVolumes, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, flowViewEnabled, flowCommunities, flowGroups, flowPreviewGroupId, flowPreviewFlightId, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
 
   const [highlightedTrafficVolume, setHighlightedTrafficVolume] = useState<string | null>(null);
   const [hoveredTrafficVolume, setHoveredTrafficVolume] = useState<string | null>(null);
@@ -84,6 +84,8 @@ export default function FlowCanvas() {
         // Add hotspot layers for traffic volumes
         map.addLayer({ id: "sector-hotspot", type: "fill", source: "sectors", paint: { "fill-color": "#ef4444", "fill-opacity": 0.1 }, filter: ["==", ["get", "traffic_volume_id"], ""] });
         map.addLayer({ id: "sector-hotspot-outline", type: "line", source: "sectors", paint: { "line-color": "#ef4444", "line-width": 3, "line-opacity": 0.9 }, filter: ["==", ["get", "traffic_volume_id"], ""] });
+
+        applyTrafficVolumeVisibility(map, useSimStore.getState().showTrafficVolumes);
 
         // --- Flight lines (static geometry) ---
         const lineFC: GeoJSON.FeatureCollection = {
@@ -268,7 +270,7 @@ export default function FlowCanvas() {
   useEffect(() => { updateFlightLineFilters(mapRef.current); }, [focusMode, focusFlightIds, selectedTrafficVolume, showFlightLines]);
 
   // When flow view state changes, update rendering
-  useEffect(() => { updateFlowRendering(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups]);
+  useEffect(() => { updateFlowRendering(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups, showTrafficVolumes]);
 
   // Ensure filters also react to flow mapping toggles (e.g., Flow Basket eye button)
   useEffect(() => { updateFlightLineFilters(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups]);
@@ -557,6 +559,11 @@ function updateFlowRendering(map: maplibregl.Map | null) {
 
   // (No regulation overlay in FlowCanvas)
 
+  applyTrafficVolumeVisibility(map, sim.showTrafficVolumes);
+  if (!sim.showTrafficVolumes) {
+    return;
+  }
+
   // Dim/Hide traffic volume backgrounds when Flow View is enabled
   // Goal: make non-selected/non-hotspot sectors disappear to declutter the map
   const sectorFillId = 'sector-fill';
@@ -609,3 +616,27 @@ function updateFlowRendering(map: maplibregl.Map | null) {
 }
 
 // (Slack overlay and helpers removed in FlowCanvas)
+
+function applyTrafficVolumeVisibility(map: maplibregl.Map, visible: boolean) {
+  const visibility = visible ? 'visible' : 'none';
+  const layerIds = [
+    'sector-fill',
+    'sector-outline',
+    'sector-labels',
+    'sector-highlight',
+    'sector-highlight-outline',
+    'sector-hover',
+    'sector-hover-outline',
+    'sector-hotspot',
+    'sector-hotspot-outline',
+  ];
+
+  for (const layerId of layerIds) {
+    if (!map.getLayer(layerId)) continue;
+    try {
+      map.setLayoutProperty(layerId, 'visibility', visibility);
+    } catch (err) {
+      console.warn(`Unable to update visibility for layer ${layerId}`, err);
+    }
+  }
+}

--- a/src/components/MapCanvas.tsx
+++ b/src/components/MapCanvas.tsx
@@ -18,7 +18,7 @@ export default function MapCanvas() {
   const mapRef = useRef<maplibregl.Map|null>(null);
   const rafRef = useRef<number | undefined>(undefined);
   const lastTs = useRef<number>(performance.now());
-  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showCallsigns, showWaypoints, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, setFocusMode, setFocusFlightIds, showHotspots, hotspots, getActiveHotspots, flowPreviewFlightId, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
+  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showCallsigns, showWaypoints, showTrafficVolumes, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, setFocusMode, setFocusFlightIds, showHotspots, hotspots, getActiveHotspots, flowPreviewFlightId, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
   const lastUpdateRef = useRef<number>(performance.now());
 
   const theme = useThemeStore((state) => state.theme);
@@ -161,6 +161,8 @@ export default function MapCanvas() {
         },
         filter: ["==", ["get", "traffic_volume_id"], ""]
       });
+
+      applyTrafficVolumeVisibility(map, useSimStore.getState().showTrafficVolumes);
 
       // --- Flight lines (static geometry) ---
       const lineFC: GeoJSON.FeatureCollection = {
@@ -558,6 +560,38 @@ export default function MapCanvas() {
     }
   }, [showCallsigns]);
 
+  // on traffic volume visibility change, toggle sector layers once map is ready
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const apply = () => {
+      try {
+        applyTrafficVolumeVisibility(map, showTrafficVolumes);
+      } catch (err) {
+        console.error("Failed to update traffic volume visibility", err);
+      }
+    };
+
+    if (map.isStyleLoaded()) {
+      apply();
+      return;
+    }
+
+    let cancelled = false;
+    const waitForReady = () => {
+      if (!map.isStyleLoaded()) return;
+      try { map.off("render", waitForReady); } catch {}
+      if (!cancelled) apply();
+    };
+
+    map.on("render", waitForReady);
+    return () => {
+      cancelled = true;
+      try { map.off("render", waitForReady); } catch {}
+    };
+  }, [showTrafficVolumes]);
+
   // on showWaypoints change, toggle waypoint visibility via paint properties
   useEffect(() => {
     if (mapRef.current) {
@@ -818,6 +852,30 @@ export default function MapCanvas() {
       </div> */}
     </>
   );
+}
+
+function applyTrafficVolumeVisibility(map: maplibregl.Map, visible: boolean) {
+  const visibility = visible ? "visible" : "none";
+  const layerIds = [
+    "sector-fill",
+    "sector-outline",
+    "sector-labels",
+    "sector-highlight",
+    "sector-highlight-outline",
+    "sector-hover",
+    "sector-hover-outline",
+    "sector-hotspot",
+    "sector-hotspot-outline",
+  ];
+
+  for (const layerId of layerIds) {
+    if (!map.getLayer(layerId)) continue;
+    try {
+      map.setLayoutProperty(layerId, "visibility", visibility);
+    } catch (err) {
+      console.warn(`Unable to update visibility for layer ${layerId}`, err);
+    }
+  }
 }
 
 function emptyFC(): GeoJSON.FeatureCollection { return { type: "FeatureCollection", features: [] }; }

--- a/src/components/RegulationCanvas.tsx
+++ b/src/components/RegulationCanvas.tsx
@@ -19,7 +19,7 @@ export default function RegulationCanvas() {
   const rafRef = useRef<number | undefined>(undefined);
   const lastTs = useRef<number>(performance.now());
   const lastUpdateRef = useRef<number>(performance.now());
-  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showFlightLines, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, regulationTargetFlightIds, addRegulationTargetFlight, selectedTrafficVolume, isRegulationPanelOpen, isResultsOpen, regulationSimulationResult, setIsResultsOpen, setRegulationSimulationResult, flowViewEnabled, flowCommunities, flowGroups, flowPreviewFlightId, flowPreviewGroupId, focusMode, focusFlightIds, slackMode, setSlackMode, slackSign, deltaMin, setIsFetchingSlack, playing } = useSimStore();
+  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showFlightLines, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, showTrafficVolumes, regulationTargetFlightIds, addRegulationTargetFlight, selectedTrafficVolume, isRegulationPanelOpen, isResultsOpen, regulationSimulationResult, setIsResultsOpen, setRegulationSimulationResult, flowViewEnabled, flowCommunities, flowGroups, flowPreviewFlightId, flowPreviewGroupId, focusMode, focusFlightIds, slackMode, setSlackMode, slackSign, deltaMin, setIsFetchingSlack, playing } = useSimStore();
   
   const [highlightedTrafficVolume, setHighlightedTrafficVolume] = useState<string | null>(null);
   const [hoveredTrafficVolume, setHoveredTrafficVolume] = useState<string | null>(null);
@@ -98,6 +98,8 @@ export default function RegulationCanvas() {
       // Add hotspot layers for traffic volumes
       map.addLayer({ id: "sector-hotspot", type: "fill", source: "sectors", paint: { "fill-color": "#ef4444", "fill-opacity": 0.1 }, filter: ["==", ["get", "traffic_volume_id"], ""] });
       map.addLayer({ id: "sector-hotspot-outline", type: "line", source: "sectors", paint: { "line-color": "#ef4444", "line-width": 3, "line-opacity": 0.9 }, filter: ["==", ["get", "traffic_volume_id"], ""] });
+
+      applyTrafficVolumeVisibility(map, useSimStore.getState().showTrafficVolumes);
 
       // --- Flight lines (static geometry) ---
       const lineFC: GeoJSON.FeatureCollection = {
@@ -310,7 +312,7 @@ export default function RegulationCanvas() {
   useEffect(() => { updateFlightLineFilters(mapRef.current); }, [focusMode, focusFlightIds, selectedTrafficVolume, showFlightLines]);
 
   // When flow view state changes, update rendering
-  useEffect(() => { updateFlowRendering(mapRef.current); updateRegulationHighlight(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups]);
+  useEffect(() => { updateFlowRendering(mapRef.current); updateRegulationHighlight(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups, showTrafficVolumes]);
 
   // Update regulation highlight when target ids change
   useEffect(() => { updateRegulationHighlight(mapRef.current); }, [regulationTargetFlightIds, flowViewEnabled]);
@@ -478,6 +480,7 @@ export default function RegulationCanvas() {
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
+    if (!showTrafficVolumes) { hideSlackOverlay(map); return; }
     if (!selectedTrafficVolume || !highlightedTrafficVolume) { hideSlackOverlay(map); setSlackMode('off'); return; }
     const refStr = formatSecondsToHHMM(t);
     const key = `${selectedTrafficVolume}|${refStr}|${slackSign}|${deltaMin}`;
@@ -485,18 +488,18 @@ export default function RegulationCanvas() {
     lastSlackKeyRef.current = key;
     const showNow = slackMode !== 'off';
     fetchAndApplySlack(map, selectedTrafficVolume, refStr, slackSign, deltaMin, setIsFetchingSlack, setSlackMetaByTv, showNow);
-  }, [selectedTrafficVolume, highlightedTrafficVolume, slackSign, deltaMin, t, slackMode, setSlackMode, setIsFetchingSlack]);
+  }, [selectedTrafficVolume, highlightedTrafficVolume, slackSign, deltaMin, t, slackMode, setSlackMode, setIsFetchingSlack, showTrafficVolumes]);
 
   // Show/hide slack overlay based on mode (Off/Minus/Plus)
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
-    if (slackMode === 'off') {
+    if (!showTrafficVolumes || slackMode === 'off') {
       hideSlackOverlay(map);
     } else if (map.getLayer('sector-slack')) {
       map.setLayoutProperty('sector-slack', 'visibility', 'visible');
     }
-  }, [slackMode]);
+  }, [slackMode, showTrafficVolumes]);
 
   return (
     <>
@@ -683,6 +686,14 @@ function updateFlowRendering(map: maplibregl.Map | null) {
     map.setLayoutProperty('reg-target-lines', 'visibility', vis);
   }
 
+  applyTrafficVolumeVisibility(map, sim.showTrafficVolumes);
+  if (!sim.showTrafficVolumes) {
+    if (map.getLayer('sector-slack')) {
+      map.setLayoutProperty('sector-slack', 'visibility', 'none');
+    }
+    return;
+  }
+
   // Dim/Hide traffic volume backgrounds when Flow View is enabled
   // Goal: make non-selected/non-hotspot sectors disappear to declutter the map
   const sectorFillId = 'sector-fill';
@@ -777,7 +788,8 @@ async function fetchAndApplySlack(
     }
     setSlackMetaByTv(metaRecord);
     applySlackOverlay(map, slackByTv);
-    if (showImmediately) {
+    const showTraffic = useSimStore.getState().showTrafficVolumes;
+    if (showImmediately && showTraffic) {
       if (map.getLayer('sector-slack')) {
         map.setLayoutProperty('sector-slack', 'visibility', 'visible');
       }
@@ -846,5 +858,29 @@ function hideSlackOverlay(map: maplibregl.Map) {
   if (!map || !map.isStyleLoaded()) return;
   if (map.getLayer('sector-slack')) {
     map.setLayoutProperty('sector-slack', 'visibility', 'none');
+  }
+}
+
+function applyTrafficVolumeVisibility(map: maplibregl.Map, visible: boolean) {
+  const visibility = visible ? 'visible' : 'none';
+  const layerIds = [
+    'sector-fill',
+    'sector-outline',
+    'sector-labels',
+    'sector-highlight',
+    'sector-highlight-outline',
+    'sector-hover',
+    'sector-hover-outline',
+    'sector-hotspot',
+    'sector-hotspot-outline',
+  ];
+
+  for (const layerId of layerIds) {
+    if (!map.getLayer(layerId)) continue;
+    try {
+      map.setLayoutProperty(layerId, 'visibility', visibility);
+    } catch (err) {
+      console.warn(`Unable to update visibility for layer ${layerId}`, err);
+    }
   }
 }

--- a/src/components/ViewOptionsControl.tsx
+++ b/src/components/ViewOptionsControl.tsx
@@ -24,6 +24,8 @@ export default function ViewOptionsControl({ embedded = false, className }: View
     setShowFlightLines,
     showWaypoints,
     setShowWaypoints,
+    showTrafficVolumes,
+    setShowTrafficVolumes,
     flLowerBound,
     flUpperBound,
     setFlRange,
@@ -158,6 +160,16 @@ export default function ViewOptionsControl({ embedded = false, className }: View
 
         {/* Right: Icon Toggles */}
         <div className="flex items-center gap-2">
+          <IconToggle
+            title="Traffic Volumes"
+            active={showTrafficVolumes}
+            onClick={() => setShowTrafficVolumes(!showTrafficVolumes)}
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <rect x={4} y={4} width={16} height={16} rx={2} ry={2} strokeWidth={2} />
+            </svg>
+          </IconToggle>
+
           <IconToggle
             title="Flight Lines"
             active={showFlightLines}

--- a/src/components/useSimStore.ts
+++ b/src/components/useSimStore.ts
@@ -75,6 +75,7 @@ type State = {
   showCallsigns: boolean;
   showFlightLines: boolean;
   showWaypoints: boolean;
+  showTrafficVolumes: boolean;
   selectedTrafficVolume: string | null;
   selectedTrafficVolumeData: { properties: SectorFeatureProps } | null;
   flLowerBound: number;
@@ -130,6 +131,7 @@ type State = {
   setShowCallsigns: (show: boolean) => void;
   setShowFlightLines: (show: boolean) => void;
   setShowWaypoints: (show: boolean) => void;
+  setShowTrafficVolumes: (show: boolean) => void;
   setSelectedTrafficVolume: (tv: string | null, tvData?: { properties: SectorFeatureProps } | null) => void;
   setFlLowerBound: (fl: number) => void;
   setFlUpperBound: (fl: number) => void;
@@ -223,6 +225,7 @@ const defaultState: Pick<State,
   | 'showCallsigns'
   | 'showFlightLines'
   | 'showWaypoints'
+  | 'showTrafficVolumes'
   | 'selectedTrafficVolume'
   | 'selectedTrafficVolumeData'
   | 'flLowerBound'
@@ -272,6 +275,7 @@ const defaultState: Pick<State,
   showCallsigns: false,
   showFlightLines: true,
   showWaypoints: true,
+  showTrafficVolumes: true,
   selectedTrafficVolume: null,
   selectedTrafficVolumeData: null,
   flLowerBound: 0,
@@ -351,6 +355,7 @@ export const useSimStore = create(persist<State, [], [], Pick<State, 'user'>>((s
   setShowCallsigns: (show) => set({ showCallsigns: show }),
   setShowFlightLines: (show) => set({ showFlightLines: show }),
   setShowWaypoints: (show) => set({ showWaypoints: show }),
+  setShowTrafficVolumes: (show) => set({ showTrafficVolumes: show }),
   setSelectedTrafficVolume: (tv, tvData = null) => set({ selectedTrafficVolume: tv, selectedTrafficVolumeData: tvData }),
   setFlLowerBound: (fl) => set({ flLowerBound: fl }),
   setFlUpperBound: (fl) => set({ flUpperBound: fl }),


### PR DESCRIPTION
## Summary
- add persistent `showTrafficVolumes` state and toggle control for map airspace visibility
- update map, flow, and regulation canvases to honor the toggle and hide sector layers and slack overlay safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb25f6fb18832bb35e98ca129b5be0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Traffic Volumes toggle in View Options to show/hide traffic volume overlays across all map views.
  - Introduced a hover tooltip showing Slack distribution details (time window, value, occupancy) near the hovered traffic volume.

- Improvements
  - Faster rendering when Traffic Volumes are hidden by skipping heavy drawing.
  - More reliable initialization and syncing of sector/volume layer visibility on load and when toggling.
  - Updated flight-line colors to reflect dominant travel direction for clearer visual cues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->