### PR TITLE
Refactor time scrubber popover

### DIFF
--- a/src/components/TimeScrubberPopover.tsx
+++ b/src/components/TimeScrubberPopover.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import {
+  useEffect,
+  useState,
+  type ChangeEvent,
+  type FocusEvent,
+  type KeyboardEvent,
+  type PointerEvent,
+} from "react";
+import { createPortal } from "react-dom";
+import { formatSecondsToHHMMSS } from "@/lib/time";
+
+type TimeScrubberPopoverProps = {
+  anchor: HTMLElement | null;
+  open: boolean;
+  value: number;
+  onChange: (value: number) => void;
+  onCommit: (value: number) => void;
+};
+
+type Position = {
+  top: number;
+  left: number;
+};
+
+const SLIDER_MIN = 0;
+const SLIDER_MAX = 24 * 3600 - 1;
+const SLIDER_STEP = 60;
+
+export default function TimeScrubberPopover({
+  anchor,
+  open,
+  value,
+  onChange,
+  onCommit,
+}: TimeScrubberPopoverProps) {
+  const [mounted, setMounted] = useState(false);
+  const [position, setPosition] = useState<Position | null>(null);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open || !anchor) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const rect = anchor.getBoundingClientRect();
+      setPosition({
+        top: rect.top + window.scrollY,
+        left: rect.left + window.scrollX + rect.width / 2,
+      });
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [anchor, open]);
+
+  if (!mounted || !open || !anchor || !position) {
+    return null;
+  }
+
+  const commitValue = (input: HTMLInputElement | null) => {
+    if (!input) return;
+    const nextValue = Number(input.value);
+    onCommit(Number.isFinite(nextValue) ? nextValue : value);
+  };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const nextValue = Number(event.currentTarget.value);
+    onChange(Number.isFinite(nextValue) ? nextValue : value);
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLInputElement>) => {
+    commitValue(event.currentTarget);
+  };
+
+  const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+    commitValue(event.currentTarget);
+  };
+
+  const handleKeyUp = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (
+      event.key === "ArrowLeft" ||
+      event.key === "ArrowRight" ||
+      event.key === "ArrowUp" ||
+      event.key === "ArrowDown" ||
+      event.key === "Home" ||
+      event.key === "End" ||
+      event.key === "PageUp" ||
+      event.key === "PageDown" ||
+      event.key === "Enter"
+    ) {
+      commitValue(event.currentTarget);
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 pointer-events-none">
+      <div
+        className="absolute pointer-events-auto"
+        style={{ top: position.top, left: position.left }}
+      >
+        <div className="transform -translate-x-1/2 -translate-y-full -mt-3 px-3 py-2 rounded-xl border border-white/20 bg-slate-900/95 backdrop-blur-md shadow-lg">
+          <div className="flex items-center gap-2">
+            <input
+              type="range"
+              min={SLIDER_MIN}
+              max={SLIDER_MAX}
+              step={SLIDER_STEP}
+              value={Math.floor(value)}
+              onChange={handleChange}
+              onPointerUp={handlePointerUp}
+              onBlur={handleBlur}
+              onKeyUp={handleKeyUp}
+              className="w-[280px] h-1.5 bg-white/20 rounded-lg appearance-none cursor-pointer"
+            />
+            <span className="text-xs font-mono">{formatSecondsToHHMMSS(value)}</span>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/ViewOptionsControl.tsx
+++ b/src/components/ViewOptionsControl.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useSimStore } from "@/components/useSimStore";
-import { ReactNode, useMemo, useState, useEffect } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import FlightLevelRangeControl from "@/components/FlightLevelRangeControl";
+import TimeScrubberPopover from "@/components/TimeScrubberPopover";
+import { useSimStore } from "@/components/useSimStore";
+import { formatSecondsToHHMMSS } from "@/lib/time";
 
 type ViewOptionsControlProps = {
   embedded?: boolean;
@@ -36,6 +38,7 @@ export default function ViewOptionsControl({ embedded = false, className }: View
   const { dow, month, day } = useMemo(() => formatDateParts(date), [date]);
 
   const [showTimeSeeker, setShowTimeSeeker] = useState(false);
+  const timeButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const [localT, setLocalT] = useState(t);
   // Sync local state if global state changes (e.g., from playback)
@@ -44,6 +47,12 @@ export default function ViewOptionsControl({ embedded = false, className }: View
   }, [t]);
 
   const minimized = embedded ? false : viewOptionsMinimized;
+
+  useEffect(() => {
+    if (minimized) {
+      setShowTimeSeeker(false);
+    }
+  }, [minimized]);
 
   const panelCard = (
     <div
@@ -64,7 +73,7 @@ export default function ViewOptionsControl({ embedded = false, className }: View
               onChange={(e) => setT(Number(e.currentTarget.value))}
               className="w-[240px] h-1.5 bg-white/20 rounded-lg appearance-none cursor-pointer"
             />
-            <span className="text-xs font-mono">{fmt(t)}</span>
+            <span className="text-xs font-mono">{formatSecondsToHHMMSS(t)}</span>
           </div>
         )}
         {/* Left: Date, Time, Speed */}
@@ -74,37 +83,21 @@ export default function ViewOptionsControl({ embedded = false, className }: View
             <div className="text-xl font-extrabold">{day}</div>
           </div>
           <div className="h-6 w-px bg-white/30" />
-          <div className="relative">
+          <div>
             <button
+              ref={timeButtonRef}
               type="button"
               className="leading-tight text-left"
-              onClick={() => setShowTimeSeeker(v => !v)}
+              onClick={() => setShowTimeSeeker((v) => !v)}
               aria-expanded={showTimeSeeker}
+              aria-haspopup="dialog"
               title="Click to toggle time seeker"
             >
               <div className="text-[10px] tracking-wider uppercase opacity-70">Operation Time</div>
               <div className="text-xl font-bold tabular-nums">
-                {fmt(t)} <span className="text-xs opacity-70 ml-1">UTC</span>
+                {formatSecondsToHHMMSS(t)} <span className="text-xs opacity-70 ml-1">UTC</span>
               </div>
             </button>
-            {showTimeSeeker && (
-              <div className="absolute left-1/2 -translate-x-1/2 -top-12 z-50 px-3 py-2 rounded-xl border border-white/20 bg-slate-900/95 backdrop-blur-md shadow-lg">
-                <div className="flex items-center gap-2">
-                  <input
-                    type="range"
-                    min={0}
-                    max={24 * 3600 - 1}
-                    step={60}
-                    value={Math.floor(localT)}
-                    onChange={(e) => setLocalT(Number(e.currentTarget.value))}
-                    onMouseUp={() => setT(localT)}
-                    onTouchEnd={() => setT(localT)}
-                    className="w-[280px] h-1.5 bg-white/20 rounded-lg appearance-none cursor-pointer"
-                  />
-                  <span className="text-xs font-mono">{fmt(localT)}</span>
-                </div>
-              </div>
-            )}
           </div>
           <div className="h-6 w-px bg-white/30" />
           <div className="flex items-center gap-2">
@@ -217,12 +210,31 @@ export default function ViewOptionsControl({ embedded = false, className }: View
     </div>
   );
 
+  const timeScrubberPopover = (
+    <TimeScrubberPopover
+      anchor={timeButtonRef.current}
+      open={showTimeSeeker}
+      value={localT}
+      onChange={setLocalT}
+      onCommit={(nextValue) => {
+        setLocalT(nextValue);
+        setT(nextValue);
+      }}
+    />
+  );
+
   if (embedded) {
-    return panelCard;
+    return (
+      <>
+        {panelCard}
+        {timeScrubberPopover}
+      </>
+    );
   }
 
   return (
     <>
+      {timeScrubberPopover}
       <div className="fixed left-1/2 bottom-0 -translate-x-1/2 z-40 pointer-events-none">
         <div
           className={`transform transition-all duration-300 ease-in-out ${
@@ -288,13 +300,6 @@ function IconToggle({ title, active, onClick, children }: { title: string; activ
       {children}
     </button>
   );
-}
-
-function fmt(sec: number) {
-  const h = Math.floor(sec / 3600).toString().padStart(2, "0");
-  const m = Math.floor((sec % 3600) / 60).toString().padStart(2, "0");
-  const s = Math.floor(sec % 60).toString().padStart(2, "0");
-  return `${h}:${m}:${s}`;
 }
 
 function formatDateParts(dateStr: string) {

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -34,3 +34,11 @@ export function parseCompactHMS(s: string): number {
   const S = clamp(Number.isFinite(ss) ? ss : 0, 0, 59);
   return H * 3600 + M * 60 + S;
 }
+
+export function formatSecondsToHHMMSS(totalSeconds: number): string {
+  const seconds = Math.max(0, Math.min(24 * 3600 - 1, Math.floor(totalSeconds)));
+  const hh = Math.floor(seconds / 3600);
+  const mm = Math.floor((seconds % 3600) / 60);
+  const ss = seconds % 60;
+  return `${String(hh).padStart(2, "0")}:${String(mm).padStart(2, "0")}:${String(ss).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary
- extract the ViewOptionsControl time scrubber into a portal-based popover so it no longer nests backdrop blur filters
- wire the popover to the existing controls with a dedicated ref and keep the local time display in sync with the store
- add a shared HH:MM:SS formatter in src/lib/time.ts for the panel and popover

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d17d8faa2c832ba6e5bc3c4f7ca39c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a popover time scrubber anchored to the Operation Time button for easier time selection.
  - Displays and edits time in HH:MM:SS with clamped 24-hour range and 1-minute steps.
  - Commits changes on pointer release, blur, or relevant keys; updates position on window resize/scroll.
  - Automatically closes when the panel is minimized.

- Refactor
  - Replaced the inline time slider with the new popover, improving clarity and reducing on-screen clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->