### PR TITLE
Add occupancy analysis to flight statistics dialog

### DIFF
--- a/src/app/api/common_traffic_volumes/route.ts
+++ b/src/app/api/common_traffic_volumes/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth, maybeHandleUnauthorized } from '@/app/api/_utils';
+
+export async function POST(request: NextRequest) {
+  try {
+    const backendUrl = process.env.BACKEND_URL || 'http://localhost:8000';
+    const payload = await request.json().catch(() => ({}));
+
+    if (!Array.isArray(payload.flight_ids) || payload.flight_ids.length === 0) {
+      return NextResponse.json(
+        { error: 'flight_ids array is required' },
+        { status: 400 }
+      );
+    }
+
+    const body = {
+      flight_ids: payload.flight_ids.map((id: unknown) => String(id)),
+    };
+
+    const resp = await fetch(`${backendUrl}/common_traffic_volumes`, {
+      method: 'POST',
+      headers: withAuth(request, { 'Content-Type': 'application/json' }),
+      body: JSON.stringify(body),
+    });
+
+    const unauthorized = await maybeHandleUnauthorized(resp);
+    if (unauthorized) return unauthorized;
+
+    const text = await resp.text();
+    if (!resp.ok) {
+      return NextResponse.json(
+        { error: `Backend error: ${resp.status}`, details: safeParseJSON(text) ?? text },
+        { status: resp.status === 404 ? 404 : 502 }
+      );
+    }
+
+    const data = safeParseJSON(text);
+    return NextResponse.json(data ?? {});
+  } catch (err) {
+    console.error('common_traffic_volumes proxy error', err);
+    return NextResponse.json(
+      { error: 'Failed to proxy common_traffic_volumes', details: err instanceof Error ? err.message : 'Unknown error' },
+      { status: 500 }
+    );
+  }
+}
+
+function safeParseJSON(text: string) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}

--- a/src/components/FlightStatisticsDialog.tsx
+++ b/src/components/FlightStatisticsDialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import ModalDialog from "./ModalDialog";
 import { useSimStore } from "./useSimStore";
+import MultiSelectWithChips, { ChipOption } from "@/components/MultiSelectWithChips";
 import {
   ResponsiveContainer,
   PieChart,
@@ -11,12 +12,16 @@ import {
   Tooltip,
   Legend,
   BarChart,
+  ComposedChart,
   CartesianGrid,
   XAxis,
   YAxis,
   Bar,
+  Line,
 } from "recharts";
 import { Trajectory } from "@/lib/models";
+import { authFetch } from "@/lib/auth";
+import { binIndexToRangeLabel } from "@/lib/time";
 
 interface FlightStatisticsDialogProps {
   open: boolean;
@@ -71,6 +76,65 @@ type LongestFlightInfo = {
   origin: string;
   destination: string;
   duration: number;
+};
+
+type CountsResponse = {
+  time_bin_minutes?: number;
+  counts?: Record<string, number[]>;
+  mentioned_counts?: Record<string, number[]>;
+  capacity?: Record<string, number[]>;
+  mentioned_capacity?: Record<string, number[]>;
+  timebins?: { labels?: string[]; start_bin?: number; end_bin?: number };
+  metadata?: Record<string, any> & { missing_flight_ids?: string[] };
+};
+
+type TrafficVolumesState = {
+  loading: boolean;
+  error: string | null;
+  ids: string[];
+  metadata: Record<string, any> | null;
+};
+
+type CountsState = {
+  loading: boolean;
+  error: string | null;
+  data: CountsResponse | null;
+};
+
+type TvOccupancyRow = {
+  idx: number;
+  label: string;
+  labelShort: string;
+  startMinute: number;
+  selected: number;
+  other: number;
+  total: number;
+  capacity: number | null;
+};
+
+type TvOccupancyMetrics = {
+  totalSum: number;
+  selectedSum: number;
+  share: number;
+  exceedance: number;
+  peakTotal: number;
+  peakSelected: number;
+};
+
+type TvOccupancyCard = {
+  tvId: string;
+  rows: TvOccupancyRow[];
+  metrics: TvOccupancyMetrics;
+  hasCapacity: boolean;
+};
+
+type TvOccupancyComputation = {
+  list: TvOccupancyCard[];
+  map: Map<string, TvOccupancyCard>;
+  minutesPerBin: number;
+  startBin: number;
+  labelCount: number;
+  minutesMismatch: boolean;
 };
 
 interface Analysis {
@@ -300,6 +364,342 @@ export default function FlightStatisticsDialog({ open, onClose, flightIds }: Fli
     };
   }, [flightIds, flights]);
 
+  const selectedFlightIds = useMemo(() => {
+    const seen = new Set<string>();
+    const ids: string[] = [];
+    for (const flight of analysis.selectedFlights) {
+      const id = String(flight.flightId ?? "").trim();
+      if (!id || seen.has(id)) continue;
+      seen.add(id);
+      ids.push(id);
+    }
+    ids.sort();
+    return ids;
+  }, [analysis.selectedFlights]);
+
+  const [trafficState, setTrafficState] = useState<TrafficVolumesState>({
+    loading: false,
+    error: null,
+    ids: [],
+    metadata: null,
+  });
+  const [overallCountsState, setOverallCountsState] = useState<CountsState>({ loading: false, error: null, data: null });
+  const [flightCountsState, setFlightCountsState] = useState<CountsState>({ loading: false, error: null, data: null });
+  const [selectedTrafficVolumes, setSelectedTrafficVolumes] = useState<string[]>([]);
+  const [rankMode, setRankMode] = useState<"selected_total" | "selected_share" | "exceedance" | "peak_selected" | "total_peak">("selected_total");
+  const [rankByParam, setRankByParam] = useState<"total_count" | "total_excess">("total_count");
+
+  const commonTrafficVolumes = useMemo(() => trafficState.ids, [trafficState.ids]);
+  const trafficOptions = useMemo<ChipOption[]>(() => commonTrafficVolumes.map(id => ({ id, label: id })), [commonTrafficVolumes]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (selectedFlightIds.length === 0) {
+      setTrafficState({ loading: false, error: null, ids: [], metadata: null });
+      setOverallCountsState({ loading: false, error: null, data: null });
+      setFlightCountsState({ loading: false, error: null, data: null });
+      return;
+    }
+    let cancelled = false;
+    setTrafficState(prev => ({ ...prev, loading: true, error: null }));
+    (async () => {
+      try {
+        const res = await authFetch("/api/common_traffic_volumes", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ flight_ids: selectedFlightIds }),
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `Failed to fetch common traffic volumes (${res.status})`);
+        }
+        const json = await res.json();
+        const ids = Array.isArray(json?.traffic_volumes)
+          ? (json.traffic_volumes as any[]).map(v => String(v)).filter(Boolean)
+          : [];
+        setTrafficState({
+          loading: false,
+          error: null,
+          ids,
+          metadata: (json?.metadata ?? null) as Record<string, any> | null,
+        });
+      } catch (err: any) {
+        if (cancelled) return;
+        setTrafficState({
+          loading: false,
+          error: err?.message || "Failed to load common traffic volumes",
+          ids: [],
+          metadata: null,
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, selectedFlightIds]);
+
+  useEffect(() => {
+    if (selectedTrafficVolumes.length === 0) return;
+    const allowed = new Set(commonTrafficVolumes);
+    if (selectedTrafficVolumes.some(id => !allowed.has(id))) {
+      setSelectedTrafficVolumes(prev => prev.filter(id => allowed.has(id)));
+    }
+  }, [commonTrafficVolumes, selectedTrafficVolumes]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (selectedFlightIds.length === 0) return;
+    if (commonTrafficVolumes.length === 0) {
+      setOverallCountsState({ loading: false, error: null, data: null });
+      setFlightCountsState({ loading: false, error: null, data: null });
+      return;
+    }
+
+    let cancelled = false;
+    const basePayload = {
+      traffic_volume_ids: commonTrafficVolumes,
+      rolling_hour: false,
+      rank_by: rankByParam,
+    };
+
+    setOverallCountsState(prev => ({ ...prev, loading: true, error: null }));
+    setFlightCountsState(prev => ({ ...prev, loading: true, error: null }));
+
+    (async () => {
+      try {
+        const res = await authFetch("/api/original_counts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(basePayload),
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `Failed to fetch original counts (${res.status})`);
+        }
+        const json = await res.json();
+        if (cancelled) return;
+        setOverallCountsState({ loading: false, error: null, data: json as CountsResponse });
+      } catch (err: any) {
+        if (cancelled) return;
+        setOverallCountsState({
+          loading: false,
+          error: err?.message || "Failed to load occupancy totals",
+          data: null,
+        });
+      }
+    })();
+
+    (async () => {
+      try {
+        const payload = { ...basePayload, flight_ids: selectedFlightIds };
+        const res = await authFetch("/api/original_counts", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (cancelled) return;
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `Failed to fetch filtered counts (${res.status})`);
+        }
+        const json = await res.json();
+        if (cancelled) return;
+        setFlightCountsState({ loading: false, error: null, data: json as CountsResponse });
+      } catch (err: any) {
+        if (cancelled) return;
+        setFlightCountsState({
+          loading: false,
+          error: err?.message || "Failed to load flight list occupancy",
+          data: null,
+        });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, selectedFlightIds, commonTrafficVolumes, rankByParam]);
+
+  const countsLoading = trafficState.loading || overallCountsState.loading || flightCountsState.loading;
+  const countsError = overallCountsState.error || flightCountsState.error;
+  const missingFlightIds = useMemo(() => (
+    Array.isArray(flightCountsState.data?.metadata?.missing_flight_ids)
+      ? (flightCountsState.data?.metadata?.missing_flight_ids as string[])
+      : []
+  ), [flightCountsState.data?.metadata?.missing_flight_ids]);
+
+  const occupancyComputation = useMemo<TvOccupancyComputation>(() => {
+    const list: TvOccupancyCard[] = [];
+    const map = new Map<string, TvOccupancyCard>();
+
+    const minutesAll = Number(overallCountsState.data?.time_bin_minutes);
+    const minutesSel = Number(flightCountsState.data?.time_bin_minutes);
+    const baseMinutes = Number.isFinite(minutesAll)
+      ? Number(minutesAll)
+      : Number.isFinite(minutesSel)
+        ? Number(minutesSel)
+        : 15;
+    const minutesPerBin = baseMinutes > 0 ? baseMinutes : 15;
+    const minutesMismatch = Number.isFinite(minutesAll) && Number.isFinite(minutesSel) && minutesAll !== minutesSel;
+    const startBin = Number(overallCountsState.data?.timebins?.start_bin ?? flightCountsState.data?.timebins?.start_bin ?? 0);
+    const labels = overallCountsState.data?.timebins?.labels ?? flightCountsState.data?.timebins?.labels ?? [];
+    const labelCount = labels.length;
+
+    if (commonTrafficVolumes.length === 0) {
+      return { list, map, minutesPerBin, startBin, labelCount, minutesMismatch };
+    }
+
+    const countsAll = extractCounts(overallCountsState.data);
+    const countsSelected = extractCounts(flightCountsState.data);
+    const capacityMap = extractCapacities(overallCountsState.data);
+    const binsPerHour = Math.max(1, Math.round(60 / Math.max(1, minutesPerBin)));
+
+    for (const tvId of commonTrafficVolumes) {
+      const totalsRaw = countsAll[tvId] || [];
+      const selectedRaw = countsSelected[tvId] || [];
+      const capacityRaw = capacityMap?.[tvId] || [];
+      const n = Math.max(labelCount, totalsRaw.length, selectedRaw.length, capacityRaw.length);
+      if (n === 0) continue;
+
+      const totalSeries = new Array(n).fill(0).map((_, idx) => safeNumber(totalsRaw[idx]));
+      const selectedSeries = new Array(n).fill(0).map((_, idx) => safeNumber(selectedRaw[idx]));
+      const capacitySeries = new Array(n).fill(null).map((_, idx) => {
+        const raw = capacityRaw[idx];
+        if (raw === undefined || raw === null) return null;
+        const num = Number(raw);
+        return Number.isFinite(num) && num >= 0 ? num : null;
+      });
+
+      const totalRolling = rollingSum(totalSeries, binsPerHour);
+      const selectedRolling = rollingSum(selectedSeries, binsPerHour);
+
+      const rows: TvOccupancyRow[] = [];
+      let totalSum = 0;
+      let selectedSum = 0;
+      let exceedance = 0;
+      let peakTotal = 0;
+      let peakSelected = 0;
+
+      for (let i = 0; i < n; i++) {
+        const total = clampNonNegative(totalRolling[i]);
+        const selected = Math.min(total, clampNonNegative(selectedRolling[i]));
+        const other = Math.max(0, total - selected);
+        const capacity = capacitySeries[i];
+        if (capacity !== null) {
+          exceedance += Math.max(0, total - capacity);
+        }
+        totalSum += total;
+        selectedSum += selected;
+        if (total > peakTotal) peakTotal = total;
+        if (selected > peakSelected) peakSelected = selected;
+        const label = labels[i] ?? binIndexToRangeLabel(startBin + i, minutesPerBin);
+        const labelShort = shortenLabel(label);
+        const startMinute = (startBin + i) * minutesPerBin;
+        rows.push({
+          idx: i,
+          label,
+          labelShort,
+          startMinute,
+          selected,
+          other,
+          total,
+          capacity,
+        });
+      }
+
+      const share = totalSum > 0 ? selectedSum / totalSum : 0;
+      const card: TvOccupancyCard = {
+        tvId,
+        rows,
+        metrics: {
+          totalSum,
+          selectedSum,
+          share,
+          exceedance,
+          peakTotal,
+          peakSelected,
+        },
+        hasCapacity: capacitySeries.some(v => Number.isFinite(v as number) && (v as number) >= 0),
+      };
+      list.push(card);
+      map.set(tvId, card);
+    }
+
+    return { list, map, minutesPerBin, startBin, labelCount, minutesMismatch };
+  }, [commonTrafficVolumes, overallCountsState.data, flightCountsState.data]);
+
+  const occupancyCards = occupancyComputation.list;
+  const occupancyMap = occupancyComputation.map;
+  const occupancyMinutesPerBin = occupancyComputation.minutesPerBin;
+  const occupancyMinutesMismatch = occupancyComputation.minutesMismatch;
+
+  const filteredCards = useMemo(() => {
+    if (selectedTrafficVolumes.length === 0) return occupancyCards;
+    const acc: TvOccupancyCard[] = [];
+    const seen = new Set<string>();
+    for (const id of selectedTrafficVolumes) {
+      if (seen.has(id)) continue;
+      seen.add(id);
+      const card = occupancyMap.get(id);
+      if (card) acc.push(card);
+    }
+    return acc;
+  }, [selectedTrafficVolumes, occupancyCards, occupancyMap]);
+
+  const rankedCards = useMemo(() => {
+    const arr = [...filteredCards];
+    arr.sort((a, b) => {
+      const am = a.metrics;
+      const bm = b.metrics;
+      switch (rankMode) {
+        case "selected_share": {
+          if (bm.share !== am.share) return bm.share - am.share;
+          if (bm.selectedSum !== am.selectedSum) return bm.selectedSum - am.selectedSum;
+          break;
+        }
+        case "exceedance": {
+          if (bm.exceedance !== am.exceedance) return bm.exceedance - am.exceedance;
+          if (bm.totalSum !== am.totalSum) return bm.totalSum - am.totalSum;
+          break;
+        }
+        case "peak_selected": {
+          if (bm.peakSelected !== am.peakSelected) return bm.peakSelected - am.peakSelected;
+          if (bm.selectedSum !== am.selectedSum) return bm.selectedSum - am.selectedSum;
+          break;
+        }
+        case "total_peak": {
+          if (bm.peakTotal !== am.peakTotal) return bm.peakTotal - am.peakTotal;
+          if (bm.totalSum !== am.totalSum) return bm.totalSum - am.totalSum;
+          break;
+        }
+        case "selected_total":
+        default: {
+          if (bm.selectedSum !== am.selectedSum) return bm.selectedSum - am.selectedSum;
+          if (bm.share !== am.share) return bm.share - am.share;
+          break;
+        }
+      }
+      if (bm.totalSum !== am.totalSum) return bm.totalSum - am.totalSum;
+      return a.tvId.localeCompare(b.tvId);
+    });
+    return arr;
+  }, [filteredCards, rankMode]);
+
+  const occupancySummary = useMemo(() => {
+    if (rankedCards.length === 0) return null;
+    return rankedCards.reduce(
+      (acc, card) => {
+        acc.total += card.metrics.totalSum;
+        acc.selected += card.metrics.selectedSum;
+        acc.exceed += card.metrics.exceedance;
+        return acc;
+      },
+      { total: 0, selected: 0, exceed: 0 }
+    );
+  }, [rankedCards]);
+
   const matchedCount = analysis.selectedFlights.length;
   const title = `Flight List Insights${analysis.requestedUniqueCount > 0 ? ` (${formatCount(matchedCount)})` : ""}`;
 
@@ -413,6 +813,181 @@ export default function FlightStatisticsDialog({ open, onClose, flightIds }: Fli
                 </div>
               ))}
             </div>
+
+            <section className="bg-white/5 border border-white/10 rounded-xl p-4">
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <div className="text-[11px] uppercase tracking-wider text-white/60">Common Traffic Volumes</div>
+                    <div className="text-sm text-white/80">Rolling-hour occupancy contributions</div>
+                  </div>
+                  {occupancySummary && occupancySummary.total > 0 && (
+                    <div className="text-right text-xs text-white/70">
+                      <div>{formatCount(rankedCards.length)} volumes</div>
+                      <div>
+                        Flight list share {formatPercent(occupancySummary.selected / occupancySummary.total)}
+                      </div>
+                      {occupancySummary.exceed > 0 && (
+                        <div>Exceedance {formatNumber(occupancySummary.exceed)}</div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="flex flex-wrap items-end gap-4">
+                  <div className="flex-1 min-w-[220px]">
+                    <div className="text-[11px] opacity-80 mb-1 text-white">Filter traffic volumes</div>
+                    <MultiSelectWithChips
+                      options={trafficOptions}
+                      selectedIds={selectedTrafficVolumes}
+                      onChange={setSelectedTrafficVolumes}
+                      placeholder={trafficState.loading ? "Loading traffic volumes…" : trafficOptions.length === 0 ? "No common traffic volumes" : "Search traffic volumes"}
+                      disabled={trafficState.loading || trafficOptions.length === 0}
+                    />
+                  </div>
+                  <div className="min-w-[160px]">
+                    <div className="text-[11px] opacity-80 mb-1 text-white">Sort charts by</div>
+                    <select
+                      value={rankMode}
+                      onChange={(e) => setRankMode(e.currentTarget.value as typeof rankMode)}
+                      className="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-sm text-white/90 focus:outline-none"
+                    >
+                      <option value="selected_total">Flight list total</option>
+                      <option value="selected_share">Flight list share</option>
+                      <option value="peak_selected">Flight list peak</option>
+                      <option value="total_peak">Total peak</option>
+                      <option value="exceedance">Capacity exceedance</option>
+                    </select>
+                  </div>
+                  <div className="min-w-[160px]">
+                    <div className="text-[11px] opacity-80 mb-1 text-white">API ranking metric</div>
+                    <select
+                      value={rankByParam}
+                      onChange={(e) => setRankByParam(e.currentTarget.value as typeof rankByParam)}
+                      className="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg text-sm text-white/90 focus:outline-none"
+                    >
+                      <option value="total_count">Total count</option>
+                      <option value="total_excess">Total excess</option>
+                    </select>
+                  </div>
+                </div>
+
+                {trafficState.error && (
+                  <div className="text-xs text-rose-200 bg-rose-500/10 border border-rose-400/40 rounded-lg px-3 py-2">
+                    {trafficState.error}
+                  </div>
+                )}
+                {countsError && (
+                  <div className="text-xs text-rose-200 bg-rose-500/10 border border-rose-400/40 rounded-lg px-3 py-2">
+                    {countsError}
+                  </div>
+                )}
+                {missingFlightIds.length > 0 && (
+                  <div className="text-xs text-amber-200 bg-amber-500/10 border border-amber-500/40 rounded-lg px-3 py-2">
+                    Ignored {formatCount(missingFlightIds.length)} unknown flights in occupancy query.
+                  </div>
+                )}
+                {occupancyMinutesMismatch && (
+                  <div className="text-[11px] text-amber-200 bg-amber-500/10 border border-amber-500/40 rounded-lg px-3 py-2">
+                    Warning: bin size mismatch between total counts ({formatNumber(overallCountsState.data?.time_bin_minutes ?? NaN)} min) and filtered counts ({formatNumber(flightCountsState.data?.time_bin_minutes ?? NaN)} min).
+                  </div>
+                )}
+
+                {countsLoading ? (
+                  <div className="flex items-center gap-3 text-sm text-white/70">
+                    <div className="w-4 h-4 border-2 border-white/30 border-t-transparent rounded-full animate-spin" />
+                    <span>Loading occupancy data…</span>
+                  </div>
+                ) : rankedCards.length === 0 ? (
+                  <div className="text-xs text-white/70 border border-white/10 rounded-lg px-3 py-4 text-center">
+                    {trafficOptions.length === 0
+                      ? "The selected flights do not share any traffic volumes."
+                      : "No occupancy data available for the selected filters."}
+                  </div>
+                ) : (
+                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    {rankedCards.map(card => (
+                      <div key={`occupancy-${card.tvId}`} className="bg-white/5 border border-white/10 rounded-xl p-3">
+                        <div className="flex items-start justify-between gap-2 mb-1.5">
+                          <div className="text-sm font-semibold text-white truncate" title={card.tvId}>{card.tvId}</div>
+                          <div className="text-right text-[11px] text-white/70 leading-tight">
+                            <div>{formatPercent(card.metrics.share)} share</div>
+                            <div>{formatNumber(card.metrics.selectedSum)} / {formatNumber(card.metrics.totalSum)}</div>
+                          </div>
+                        </div>
+                        <div className="text-[11px] text-white/60 mb-2 flex flex-wrap gap-3">
+                          <span className="flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-sm bg-sky-400" />
+                            Flight list
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <span className="inline-block w-2 h-2 rounded-sm bg-slate-400" />
+                            Others
+                          </span>
+                          {card.hasCapacity && (
+                            <span className="flex items-center gap-1">
+                              <span className="inline-block w-4 h-[2px] bg-amber-300" />
+                              Capacity
+                            </span>
+                          )}
+                        </div>
+                        <div className="h-36">
+                          <ResponsiveContainer width="100%" height="100%">
+                            <ComposedChart data={card.rows} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+                              <CartesianGrid vertical={false} stroke="rgba(255,255,255,0.08)" />
+                              <XAxis
+                                dataKey="idx"
+                                tick={{ fontSize: 10, fill: "rgba(226,232,240,0.9)" }}
+                                interval="preserveStartEnd"
+                                height={18}
+                                tickFormatter={(value: any) => {
+                                  const idx = Number(value ?? 0);
+                                  return card.rows[idx]?.labelShort ?? card.rows[idx]?.label ?? "";
+                                }}
+                              />
+                              <YAxis
+                                tick={{ fontSize: 10, fill: "rgba(226,232,240,0.9)" }}
+                                axisLine={false}
+                                tickLine={false}
+                                width={28}
+                                allowDecimals={false}
+                              />
+                              <Tooltip
+                                formatter={(value: any, name) => {
+                                  const num = Number(value ?? 0);
+                                  if (name === "selected") return [formatNumber(num), "Flight list"];
+                                  if (name === "other") return [formatNumber(num), "Others"];
+                                  if (name === "capacity") return [formatNumber(num), "Capacity"];
+                                  return [formatNumber(num), String(name)];
+                                }}
+                                labelFormatter={(value: any) => {
+                                  const idx = Number(value ?? 0);
+                                  return card.rows[idx]?.label ?? `Bin ${idx}`;
+                                }}
+                                contentStyle={{ background: "rgba(15,23,42,0.95)", border: "1px solid rgba(255,255,255,0.15)", borderRadius: 8, color: "white" }}
+                                itemStyle={{ color: "white" }}
+                              />
+                              <Bar dataKey="selected" stackId="count" fill="#38bdf8" name="Flight list" />
+                              <Bar dataKey="other" stackId="count" fill="#94a3b8" name="Others" />
+                              {card.hasCapacity && (
+                                <Line type="stepAfter" dataKey="capacity" stroke="#facc15" strokeWidth={1.5} dot={false} name="Capacity" />
+                              )}
+                            </ComposedChart>
+                          </ResponsiveContainer>
+                        </div>
+                        <div className="mt-2 text-[11px] text-white/60 flex flex-wrap gap-3">
+                          <span>Peak {formatNumber(card.metrics.peakSelected)} / {formatNumber(card.metrics.peakTotal)}</span>
+                          {card.metrics.exceedance > 0 && (
+                            <span>Exceed {formatNumber(card.metrics.exceedance)}</span>
+                          )}
+                          <span>{formatCount(card.rows.length)} bins · {occupancyMinutesPerBin}m</span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </section>
 
             <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
               <div className="bg-white/5 border border-white/10 rounded-xl p-4 flex flex-col">
@@ -815,6 +1390,55 @@ function createAirportTotals(originCounts: Map<string, number>, destinationCount
     .slice(0, limit);
 }
 
+function safeNumber(value: unknown): number {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function clampNonNegative(value: unknown): number {
+  const num = safeNumber(value);
+  return num > 0 ? num : 0;
+}
+
+function extractCounts(data: CountsResponse | null | undefined): Record<string, number[]> {
+  if (!data) return {};
+  const mentioned = data.mentioned_counts;
+  if (mentioned && Object.keys(mentioned).length > 0) return mentioned;
+  return data.counts ?? {};
+}
+
+function extractCapacities(data: CountsResponse | null | undefined): Record<string, number[]> | undefined {
+  if (!data) return undefined;
+  const mentioned = data.mentioned_capacity;
+  if (mentioned && Object.keys(mentioned).length > 0) return mentioned;
+  return data.capacity ?? undefined;
+}
+
+function shortenLabel(label: string): string {
+  if (!label) return "";
+  const dash = label.indexOf("-");
+  const short = dash > 0 ? label.slice(0, dash) : label;
+  return short.trim();
+}
+
+function rollingSum(arr: number[], windowSize: number): number[] {
+  const n = arr.length;
+  if (n === 0) return [];
+  if (windowSize <= 1) {
+    return arr.map(v => clampNonNegative(v));
+  }
+  const out = new Array(n).fill(0);
+  let windowSum = 0;
+  for (let i = 0; i < n; i++) {
+    windowSum += clampNonNegative(arr[i]);
+    if (i >= windowSize) {
+      windowSum -= clampNonNegative(arr[i - windowSize]);
+    }
+    out[i] = windowSum;
+  }
+  return out;
+}
+
 function formatTimeOfDay(seconds: number | null): string {
   if (!Number.isFinite(seconds ?? NaN)) return "—";
   const totalSeconds = Math.max(0, Math.round(seconds ?? 0));
@@ -837,6 +1461,21 @@ function formatDuration(seconds: number | null): string {
 function formatCount(value: number): string {
   if (!Number.isFinite(value)) return "0";
   return Number(value).toLocaleString("en-US");
+}
+
+function formatNumber(value: unknown): string {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return "—";
+  if (Math.abs(num) < 1e-3) return "0";
+  if (Math.abs(num - Math.round(num)) < 1e-6) {
+    return formatCount(Math.round(num));
+  }
+  const abs = Math.abs(num);
+  const fractionDigits = abs >= 1000 ? 0 : 1;
+  return num.toLocaleString("en-US", {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
 }
 
 function formatPercent(value: number): string {


### PR DESCRIPTION
## Summary
- add a proxy route for the common_traffic_volumes backend endpoint
- extend the flight statistics dialog to fetch shared traffic volumes and original counts for the selected flights
- add UI controls, ranking, and stacked occupancy charts comparing the flight list contribution versus other traffic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1bf0334e0832bb25fc2e5e9d037ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Common Traffic Volumes section with interactive occupancy cards/charts, including per-volume metrics (share, peak, exceedance) and an overall summary.
  - Introduced filtering and ranking controls (multi-select chips, rank modes/parameters) to sort and focus volumes.
  - Enabled data retrieval through a new API endpoint, with responsive loading states and cancellation-safe requests.

- Bug Fixes
  - Improved error messaging and status handling when traffic volume data is unavailable or backend responses fail, providing clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->