### PR TITLE
Add save/load support to regulation plan panel

### DIFF
--- a/src/components/RegulationPlanPanel.tsx
+++ b/src/components/RegulationPlanPanel.tsx
@@ -1,8 +1,22 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSimStore } from "@/components/useSimStore";
 import { authFetch } from "@/lib/auth";
 import ShimmeringText from "@/components/ShimmeringText";
+import ModalDialog from "./ModalDialog";
+
+type RegulationsState = ReturnType<typeof useSimStore.getState>["regulations"];
+
+type SavedRegulationPlan = {
+  id: string;
+  label: string;
+  savedAt: number;
+  data: {
+    regulations: RegulationsState;
+  };
+};
+
+const REGULATION_PLAN_STORAGE_KEY = "regulation-plan-saves";
 
 interface RegulationPlanPanelProps {
   isRegulationPanelOpen: boolean;
@@ -15,6 +29,120 @@ export default function RegulationPlanPanel({ isRegulationPanelOpen, embedded = 
   const [isSimulating, setIsSimulating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [isMinimized, setIsMinimized] = useState(false);
+  const [saveModalOpen, setSaveModalOpen] = useState(false);
+  const [loadModalOpen, setLoadModalOpen] = useState(false);
+  const [saveLabel, setSaveLabel] = useState("");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveTimestamp, setSaveTimestamp] = useState<number | null>(null);
+  const [loadSearch, setLoadSearch] = useState("");
+  const [savedPlans, setSavedPlans] = useState<SavedRegulationPlan[]>([]);
+
+  useEffect(() => {
+    setSavedPlans(loadSavedPlansFromStorage());
+  }, []);
+
+  useEffect(() => {
+    if (saveModalOpen) {
+      const now = Date.now();
+      setSaveTimestamp(now);
+      setSaveError(null);
+      setSaveLabel((prev) => {
+        if (prev.trim()) return prev;
+        return `Plan ${formatDateTime(now)}`;
+      });
+    } else {
+      setSaveTimestamp(null);
+    }
+  }, [saveModalOpen]);
+
+  useEffect(() => {
+    if (loadModalOpen) {
+      setLoadSearch("");
+    }
+  }, [loadModalOpen]);
+
+  const totalFlights = useMemo(() => {
+    return regulations.reduce((sum, r) => sum + (r.flightCallsigns?.length || 0), 0);
+  }, [regulations]);
+
+  const filteredSavedPlans = useMemo(() => {
+    const query = loadSearch.trim().toLowerCase();
+    if (!query) return savedPlans;
+    return savedPlans.filter((plan) => plan.label.toLowerCase().includes(query));
+  }, [savedPlans, loadSearch]);
+
+  const closeSaveModal = () => {
+    setSaveModalOpen(false);
+    setSaveError(null);
+    setSaveLabel("");
+  };
+
+  const closeLoadModal = () => {
+    setLoadModalOpen(false);
+    setLoadSearch("");
+  };
+
+  const handleSavePlan = () => {
+    setSaveError(null);
+    const trimmed = saveLabel.trim();
+    if (!trimmed) {
+      setSaveError("Label is required");
+      return;
+    }
+    const now = Date.now();
+    const planData = {
+      regulations: deepCopy(regulations),
+    };
+    const existingIndex = savedPlans.findIndex((plan) => plan.label.toLowerCase() === trimmed.toLowerCase());
+    let nextPlans: SavedRegulationPlan[];
+    if (existingIndex >= 0) {
+      const existing = savedPlans[existingIndex];
+      nextPlans = savedPlans.slice();
+      nextPlans[existingIndex] = {
+        ...existing,
+        label: trimmed,
+        savedAt: now,
+        data: planData,
+      };
+    } else {
+      const newPlan: SavedRegulationPlan = {
+        id: `plan-${now}-${Math.floor(Math.random() * 1000)}`,
+        label: trimmed,
+        savedAt: now,
+        data: planData,
+      };
+      nextPlans = [...savedPlans, newPlan];
+    }
+    const sortedPlans = nextPlans.slice().sort((a, b) => b.savedAt - a.savedAt);
+    if (!persistSavedRegulationPlans(sortedPlans)) {
+      setSaveError("Failed to save plan to local storage. Check your browser settings.");
+      return;
+    }
+    setSavedPlans(sortedPlans);
+    closeSaveModal();
+  };
+
+  const handleLoadPlan = (plan: SavedRegulationPlan) => {
+    try {
+      const clonedRegs = deepCopy(plan.data.regulations || []);
+      useSimStore.setState({ regulations: clonedRegs });
+      setSelectedRegulation(null);
+      setRegulationSimulationResult(null);
+      closeLoadModal();
+    } catch (err) {
+      console.warn("Failed to load saved regulation plan", err);
+    }
+  };
+
+  const handleDeletePlan = (plan: SavedRegulationPlan) => {
+    if (typeof window !== "undefined") {
+      const confirmed = window.confirm(`Delete saved plan "${plan.label}"?`);
+      if (!confirmed) return;
+    }
+    const next = savedPlans.filter((p) => p.id !== plan.id);
+    if (!persistSavedRegulationPlans(next)) return;
+    setSavedPlans(next);
+  };
 
   function formatTime(seconds: number): string {
     const hours = Math.floor(seconds / 3600);
@@ -36,6 +164,125 @@ export default function RegulationPlanPanel({ isRegulationPanelOpen, embedded = 
 
   return (
     <>
+      {saveModalOpen && (
+        <ModalDialog
+          open={saveModalOpen}
+          onClose={closeSaveModal}
+          title="Save Regulation Plan"
+          description="Store the current regulations locally."
+          width="w-[min(520px,95vw)]"
+          height="h-auto max-h-[85vh]"
+        >
+          <div className="space-y-4 px-5 py-5">
+            <label className="block text-sm">
+              <span className="mb-1 block text-[11px] uppercase tracking-wide text-white/60">Plan label</span>
+              <input
+                value={saveLabel}
+                onChange={(e) => {
+                  setSaveLabel(e.currentTarget.value);
+                  setSaveError(null);
+                }}
+                className="w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+                placeholder="Morning regs for EDDF"
+              />
+            </label>
+            {saveError && <div className="text-[11px] text-red-200">{saveError}</div>}
+            <div className="text-[12px] text-white/70">
+              {regulations.length} regulation{regulations.length === 1 ? "" : "s"} • {totalFlights} flight{totalFlights === 1 ? "" : "s"}
+            </div>
+            <div className="text-[12px] text-white/50">
+              Timestamp: {formatDateTime(saveTimestamp ?? Date.now())}
+            </div>
+          </div>
+          <div className="flex items-center justify-end gap-3 border-t border-white/10 px-5 py-4">
+            <button
+              onClick={closeSaveModal}
+              className="rounded-lg border border-white/20 bg-white/5 px-4 py-2 text-sm text-white/80 hover:bg-white/10"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSavePlan}
+              className="rounded-lg bg-gradient-to-r from-indigo-500 to-purple-500 px-4 py-2 text-sm font-medium text-white shadow hover:opacity-90"
+            >
+              Save plan
+            </button>
+          </div>
+        </ModalDialog>
+      )}
+      {loadModalOpen && (
+        <ModalDialog
+          open={loadModalOpen}
+          onClose={closeLoadModal}
+          title="Load Regulation Plan"
+          description="Pick a saved plan to restore it into the regulation list."
+          width="w-[min(880px,95vw)]"
+          height="h-auto max-h-[85vh]"
+        >
+          <div className="border-b border-white/10 px-5 py-4">
+            <div className="relative">
+              <input
+                value={loadSearch}
+                onChange={(e) => setLoadSearch(e.currentTarget.value)}
+                placeholder="Search saved plans..."
+                className="w-full rounded-lg border border-white/20 bg-white/10 px-3 py-2 text-sm text-white placeholder:text-white/60 focus:outline-none focus:ring-2 focus:ring-indigo-400/40"
+              />
+              <svg
+                className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-white/60"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m21 21-6-6m2-5a7 7 0 1 1-14 0 7 7 0 0 1 14 0z" />
+              </svg>
+            </div>
+          </div>
+          <div className="max-h-80 space-y-3 overflow-y-auto px-5 py-4">
+            {filteredSavedPlans.length === 0 ? (
+              <div className="text-xs text-white/60">
+                {savedPlans.length === 0 ? "No plans saved yet. Save a regulation plan to load it later." : "No saved plans match your search."}
+              </div>
+            ) : (
+              filteredSavedPlans.map((plan) => {
+                const regulationCount = plan.data.regulations?.length || 0;
+                const flightCount = (plan.data.regulations || []).reduce((sum, reg) => sum + (reg.flightCallsigns?.length || 0), 0);
+                return (
+                  <div key={plan.id} className="flex items-start justify-between gap-3 rounded-lg border border-white/10 bg-white/5 p-3">
+                    <div className="space-y-1">
+                      <div className="text-sm font-medium text-white">{plan.label}</div>
+                      <div className="text-[11px] text-white/60">Saved {formatDateTime(plan.savedAt)}</div>
+                      <div className="text-[11px] text-white/60">{regulationCount} regulation{regulationCount === 1 ? "" : "s"} • {flightCount} flight{flightCount === 1 ? "" : "s"}</div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleLoadPlan(plan)}
+                        className="rounded-lg border border-indigo-300/40 bg-indigo-500/30 px-3 py-1 text-xs font-medium text-white hover:bg-indigo-500/45"
+                      >
+                        Load
+                      </button>
+                      <button
+                        onClick={() => handleDeletePlan(plan)}
+                        className="rounded-lg border border-white/15 bg-white/5 p-2 text-white/70 transition hover:border-red-300/40 hover:bg-red-500/20 hover:text-red-100"
+                        title="Delete saved plan"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 7h12M9 7v10m6-10v10M4 7h16l-1 14H5L4 7zm5-3h6l1 3H8l1-3z" stroke="currentColor" strokeWidth="1.5"/></svg>
+                      </button>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+          </div>
+          <div className="flex items-center justify-end border-t border-white/10 px-5 py-4">
+            <button
+              onClick={closeLoadModal}
+              className="rounded-lg border border-white/20 bg-white/5 px-4 py-2 text-sm text-white/80 hover:bg-white/10"
+            >
+              Close
+            </button>
+          </div>
+        </ModalDialog>
+      )}
       {isMinimized ? (
         <button
           onClick={() => setIsMinimized(false)}
@@ -179,6 +426,30 @@ export default function RegulationPlanPanel({ isRegulationPanelOpen, embedded = 
           )}
         </div>
 
+        {/* Save / Load Plans */}
+        <div className="flex items-center justify-between">
+          <div className="text-sm opacity-80">
+            Saved plans
+            <span className="ml-2 text-[11px] opacity-60">({savedPlans.length})</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setLoadModalOpen(true)}
+              className="px-2 py-1 rounded-lg border border-white/20 bg-white/10 text-white text-xs shadow hover:bg-white/15"
+              title="Load a saved regulation plan"
+            >
+              Load plan
+            </button>
+            <button
+              onClick={() => setSaveModalOpen(true)}
+              className="px-2 py-1 rounded-lg border border-indigo-300/40 bg-indigo-500/30 text-white text-xs shadow hover:bg-indigo-500/40"
+              title="Save the current regulation plan"
+            >
+              Save plan
+            </button>
+          </div>
+        </div>
+
         {/* Action Buttons */}
         <div className="flex items-center justify-center gap-2">
           {isSimulating ? (
@@ -266,4 +537,75 @@ export default function RegulationPlanPanel({ isRegulationPanelOpen, embedded = 
       )}
     </>
   );
+}
+
+function formatDateTime(ts: number): string {
+  if (!Number.isFinite(ts)) return "—";
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return "—";
+  try {
+    return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "short" }).format(date);
+  } catch {
+    return date.toLocaleString();
+  }
+}
+
+function loadSavedPlansFromStorage(): SavedRegulationPlan[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(REGULATION_PLAN_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    const normalized = parsed
+      .map((plan: any): SavedRegulationPlan | null => {
+        if (!plan || typeof plan !== "object") return null;
+        const id = typeof plan.id === "string" ? plan.id : `plan-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+        const label = typeof plan.label === "string" && plan.label.trim() ? plan.label : "Untitled plan";
+        const savedAt = typeof plan.savedAt === "number" ? plan.savedAt : Date.now();
+        const data = plan.data && typeof plan.data === "object" ? plan.data : {};
+        const regulationsRaw = Array.isArray(data.regulations) ? data.regulations : [];
+        const regulations = regulationsRaw.map((reg: any) => ({
+          ...reg,
+          flightCallsigns: Array.isArray(reg?.flightCallsigns) ? reg.flightCallsigns.slice() : [],
+        }));
+        return {
+          id,
+          label,
+          savedAt,
+          data: {
+            regulations: regulations as RegulationsState,
+          },
+        };
+      })
+      .filter((plan): plan is SavedRegulationPlan => !!plan);
+    return normalized.sort((a, b) => b.savedAt - a.savedAt);
+  } catch (err) {
+    console.warn("Failed to load saved regulation plans", err);
+    return [];
+  }
+}
+
+function persistSavedRegulationPlans(plans: SavedRegulationPlan[]): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    window.localStorage.setItem(REGULATION_PLAN_STORAGE_KEY, JSON.stringify(plans));
+    return true;
+  } catch (err) {
+    console.warn("Failed to persist saved regulation plans", err);
+    return false;
+  }
+}
+
+function deepCopy<T>(value: T): T {
+  try {
+    const maybeClone = (globalThis as any).structuredClone;
+    if (typeof maybeClone === "function") {
+      return maybeClone(value);
+    }
+  } catch {
+    // ignore and fall back
+  }
+  if (value == null) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
 }


### PR DESCRIPTION
## Summary
- add local state, modals, and handlers to save and load regulation plans from local storage
- provide UI controls mirroring flow plan behavior including plan metadata and filtering
- include helpers for formatting timestamps, persisting plans, and cloning regulation data safely

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d93ad0a0832b81f8b1dcf4397bb0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Save and load regulation plans on your device with labels and timestamps via modal dialogs.
  * Manage saved plans: search, load, and delete (with confirmation).
  * Overview of saved plans with counts and quick actions.
  * Enhanced regulations table with per-item edit and delete actions.
  * Improved simulation flow: clearer error messages and a responsive, non-blocking UI during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->