### PR TITLE
Ensure flow rendering resets when map is still loading

### DIFF
--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -517,7 +517,21 @@ function updateFlightLineFilters(map: maplibregl.Map | null) {
 
 // Apply flow-based coloring to flight lines
 function updateFlowRendering(map: maplibregl.Map | null) {
-  if (!map || !map.isStyleLoaded()) return;
+  if (!map) {
+    return;
+  }
+  if (!map.isStyleLoaded()) {
+    try {
+      map.once("idle", () => {
+        try {
+          updateFlowRendering(map);
+        } catch (err) {
+          console.error("Deferred updateFlowRendering error:", err);
+        }
+      });
+    } catch {}
+    return;
+  }
   const sim = useSimStore.getState();
   if (!map.getLayer('flight-lines')) return;
 

--- a/src/components/RegulationCanvas.tsx
+++ b/src/components/RegulationCanvas.tsx
@@ -634,7 +634,21 @@ function updateRegulationHighlight(map: maplibregl.Map | null) {
 
 // Apply flow-based coloring to flight lines
 function updateFlowRendering(map: maplibregl.Map | null) {
-  if (!map || !map.isStyleLoaded()) return;
+  if (!map) {
+    return;
+  }
+  if (!map.isStyleLoaded()) {
+    try {
+      map.once("idle", () => {
+        try {
+          updateFlowRendering(map);
+        } catch (err) {
+          console.error("Deferred updateFlowRendering error:", err);
+        }
+      });
+    } catch {}
+    return;
+  }
   const sim = useSimStore.getState();
   if (!map.getLayer('flight-lines')) return;
 

--- a/src/components/RegulationCanvas.tsx
+++ b/src/components/RegulationCanvas.tsx
@@ -620,7 +620,19 @@ function updateFlightLineFilters(map: maplibregl.Map | null) {
 }
 
 function updateRegulationHighlight(map: maplibregl.Map | null) {
-  if (!map || !map.isStyleLoaded()) return;
+  if (!map) return;
+  if (!map.isStyleLoaded()) {
+    try {
+      map.once("idle", () => {
+        try {
+          updateRegulationHighlight(map);
+        } catch (err) {
+          console.error("Deferred updateRegulationHighlight error:", err);
+        }
+      });
+    } catch {}
+    return;
+  }
   const sim = useSimStore.getState();
   const ids = Array.from(sim.regulationTargetFlightIds).map(String);
   const filterExpr: any = ids.length > 0 ? ["in", ["to-string", ["get", "flightId"]], ["literal", ids]] : ["==", ["get", "flightId"], "__none__"];


### PR DESCRIPTION
## Summary
- guard flow rendering updates in the regulation and flow canvases until the map style has finished loading so color resets still apply when closing Flow View

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d533b7c678832bb9e5a4b20035e017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved intermittent issues where flow and regulation layers failed to appear during initial map load.
  - Prevented blank or partial overlays when the map wasn’t fully ready.

- **Performance & Stability**
  - Improved synchronization with map readiness to render layers at the appropriate time.
  - Reduced visual flicker and rendering glitches during startup for a smoother experience.
  - Enhanced error handling to avoid silent failures, improving reliability when loading complex map layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->