### PR TITLE
Ensure regulation preview highlights update

### DIFF
--- a/src/components/RegulationCanvas.tsx
+++ b/src/components/RegulationCanvas.tsx
@@ -314,7 +314,7 @@ export default function RegulationCanvas() {
   useEffect(() => { updateFlowRendering(mapRef.current); updateRegulationHighlight(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups, showTrafficVolumes]);
 
   // Update regulation highlight when target ids change
-  useEffect(() => { updateRegulationHighlight(mapRef.current); }, [regulationTargetFlightIds, flowViewEnabled]);
+  useEffect(() => { updateRegulationHighlight(mapRef.current); }, [regulationTargetFlightIds, flowViewEnabled, regulationPreviewActive]);
 
   // Weather overlay integration (Surface Precipitation)
   useEffect(() => {


### PR DESCRIPTION
## Summary
- trigger regulation highlight updates when the preview toggle changes to restore red overlays for targeted flights

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5579020f8832b8a27076d57a01476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Regulation highlights now refresh when toggling Regulation Preview, preventing outdated or missing highlights.
  * Highlights stay in sync when switching Flow View or changing target flights, improving consistency across views and interactions.
  * Overall, highlight updates are more timely and reliable, reducing visual lag and ensuring the canvas reflects the current preview and selection state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->