### PR TITLE
Add traffic volume tooltip and mini map

### DIFF
--- a/src/app/flow-evaluation/page.tsx
+++ b/src/app/flow-evaluation/page.tsx
@@ -34,6 +34,7 @@ import OccupancyPrePostPanel from "@/components/OccupancyPrePostPanel";
 import { formatSeeMoreLabel, SEE_LESS_LABEL } from "@/lib/seeMoreLess";
 import { FlowInputPayload } from "@/lib/flow-input";
 import { AutorateOccupancyResponse } from "@/lib/autorate";
+import TrafficVolumeInfoTooltip from "@/components/TrafficVolumeInfoTooltip";
 import {
   SolutionSnapshot,
   loadSnapshots,
@@ -1582,7 +1583,12 @@ function FlowEvaluationPageContent() {
                                 {controlled.has(tvId) && (
                                   <span className="text-[10px] px-1.5 py-0.5 rounded bg-rose-500/20 border border-rose-400/60 text-rose-200">Controlled</span>
                                 )}
-                                <span>{tvId}</span>
+                                <TrafficVolumeInfoTooltip
+                                  trafficVolumeId={tvId}
+                                  className="max-w-[160px] truncate"
+                                >
+                                  <span className="truncate">{tvId}</span>
+                                </TrafficVolumeInfoTooltip>
                               </div>
                             </div>
                             <div className="h-36">
@@ -2659,7 +2665,9 @@ function HistogramCard({ tvId, series, seriesB, minutesPerBin, viewFrom, viewTo,
         <div className="text-sm font-semibold text-white flex items-center gap-2">
           {isControlled && <span className="text-[10px] px-1.5 py-0.5 rounded bg-rose-500/20 border border-rose-400/70 text-rose-200">Controlled</span>}
           {markerColor && <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: markerColor }} />}
-          <span>{tvId}</span>
+          <TrafficVolumeInfoTooltip trafficVolumeId={tvId} className="max-w-[160px] truncate">
+            <span className="truncate">{tvId}</span>
+          </TrafficVolumeInfoTooltip>
         </div>
       </div>
       <div className="h-36">

--- a/src/app/original_count/page.tsx
+++ b/src/app/original_count/page.tsx
@@ -7,6 +7,7 @@ import MultiSelectWithChips, { ChipOption } from "@/components/MultiSelectWithCh
 import ShimmeringText from "@/components/ShimmeringText";
 import { loadSectors } from "@/lib/airspace";
 import TimeScaleControl from "@/components/TimeScaleControl";
+import TrafficVolumeInfoTooltip from "@/components/TrafficVolumeInfoTooltip";
 import {
   ComposedChart,
   Bar,
@@ -390,7 +391,11 @@ function ChartCard({ tvId, series, labels, minutesPerBin, capacitySeries = [], s
   return (
     <div className="bg-white/5 border border-white/10 rounded-xl p-3">
       <div className="flex items-center justify-between mb-2">
-        <div className="text-sm font-semibold text-white">{tvId}</div>
+        <div className="text-sm font-semibold text-white truncate">
+          <TrafficVolumeInfoTooltip trafficVolumeId={tvId} className="truncate max-w-full">
+            <span className="truncate">{tvId}</span>
+          </TrafficVolumeInfoTooltip>
+        </div>
       </div>
       <div className="h-36">
         <ResponsiveContainer width="100%" height="100%">

--- a/src/app/regulation-comparison/page.tsx
+++ b/src/app/regulation-comparison/page.tsx
@@ -7,6 +7,7 @@ import TimeScaleControl from "@/components/TimeScaleControl";
 import ModalDialog from "@/components/ModalDialog";
 import MultiSelectWithChips, { ChipOption } from "@/components/MultiSelectWithChips";
 import FlightStatisticsButton from "@/components/FlightStatisticsButton";
+import TrafficVolumeInfoTooltip from "@/components/TrafficVolumeInfoTooltip";
 import {
   RegulationSnapshot,
   loadRegSnapshots,
@@ -1539,7 +1540,11 @@ export default function RegulationComparisonPage() {
                 return (
                   <div key={tvId} className="rounded-lg border border-white/10 bg-white/5 p-3 space-y-3">
                     <div className="flex items-center justify-between">
-                      <div className="text-sm font-semibold text-white">{tvId}</div>
+                      <div className="text-sm font-semibold text-white truncate">
+                        <TrafficVolumeInfoTooltip trafficVolumeId={tvId} className="truncate max-w-full">
+                          <span className="truncate">{tvId}</span>
+                        </TrafficVolumeInfoTooltip>
+                      </div>
                     </div>
                     <div className="h-48">
                       {hasSeries || hasCapacity ? (

--- a/src/app/solution-comparison/page.tsx
+++ b/src/app/solution-comparison/page.tsx
@@ -7,6 +7,7 @@ import TimeScaleControl from "@/components/TimeScaleControl";
 import ModalDialog from "@/components/ModalDialog";
 import MultiSelectWithChips, { ChipOption } from "@/components/MultiSelectWithChips";
 import FlightStatisticsButton from "@/components/FlightStatisticsButton";
+import TrafficVolumeInfoTooltip from "@/components/TrafficVolumeInfoTooltip";
 import {
   SolutionSnapshot,
   loadSnapshots,
@@ -1640,7 +1641,11 @@ export default function SolutionComparisonPage() {
                 return (
                   <div key={tvId} className="rounded-lg border border-white/10 bg-white/5 p-3 space-y-3">
                     <div className="flex items-center justify-between">
-                      <div className="text-sm font-semibold text-white">{tvId}</div>
+                      <div className="text-sm font-semibold text-white truncate">
+                        <TrafficVolumeInfoTooltip trafficVolumeId={tvId} className="truncate max-w-full">
+                          <span className="truncate">{tvId}</span>
+                        </TrafficVolumeInfoTooltip>
+                      </div>
                     </div>
                     <div className="h-48">
                       {hasSeries || hasCapacity ? (

--- a/src/components/FlightListStatistics.tsx
+++ b/src/components/FlightListStatistics.tsx
@@ -2,6 +2,7 @@
 
 import { memo, useEffect, useMemo, useState } from "react";
 import { useSimStore } from "./useSimStore";
+import TrafficVolumeInfoTooltip from "./TrafficVolumeInfoTooltip";
 import MultiSelectWithChips, { ChipOption } from "@/components/MultiSelectWithChips";
 import {
   ResponsiveContainer,
@@ -1094,7 +1095,14 @@ function FlightListStatistics({
                     {visibleRankedCards.map(card => (
                       <div key={`occupancy-${card.tvId}`} className="bg-white/5 border border-white/10 rounded-xl p-3">
                         <div className="flex items-start justify-between gap-2 mb-1.5">
-                          <div className="text-sm font-semibold text-white truncate" title={card.tvId}>{card.tvId}</div>
+                          <div className="text-sm font-semibold text-white truncate">
+                            <TrafficVolumeInfoTooltip
+                              trafficVolumeId={card.tvId}
+                              className="truncate max-w-full"
+                            >
+                              <span className="truncate">{card.tvId}</span>
+                            </TrafficVolumeInfoTooltip>
+                          </div>
                           <div className="text-right text-[11px] text-white/70 leading-tight">
                             <div>{formatPercent(card.metrics.share)} share</div>
                             <div>{formatNumber(card.metrics.selectedSum)} / {formatNumber(card.metrics.totalSum)}</div>

--- a/src/components/OccupancyPrePostPanel.tsx
+++ b/src/components/OccupancyPrePostPanel.tsx
@@ -4,6 +4,7 @@ import { ComposedChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cartesi
 import { binIndexToRangeLabel, hhmmToMinutesSafe } from "@/lib/time";
 import { formatSeeMoreLabel, SEE_LESS_LABEL } from "@/lib/seeMoreLess";
 import type { OccupancySeriesByTv } from "@/lib/models";
+import TrafficVolumeInfoTooltip from "./TrafficVolumeInfoTooltip";
 
 type SortMode = "total" | "abs_change" | "exceedance";
 
@@ -237,7 +238,11 @@ export default function OccupancyPrePostPanel({
           return (
             <div key={tv} className="bg-white/5 border border-white/10 rounded-xl p-3">
               <div className="flex items-center justify-between mb-2">
-                <div className="text-sm font-semibold text-white/90">{tv}</div>
+                <div className="text-sm font-semibold text-white/90 truncate">
+                  <TrafficVolumeInfoTooltip trafficVolumeId={tv} className="truncate max-w-full">
+                    <span className="truncate">{tv}</span>
+                  </TrafficVolumeInfoTooltip>
+                </div>
               </div>
               <div className={compact ? "h-32" : "h-36"}>
                 <ResponsiveContainer width="100%" height="100%">

--- a/src/components/TrafficVolumeInfoTooltip.tsx
+++ b/src/components/TrafficVolumeInfoTooltip.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { SectorFeatureProps } from "@/lib/models";
+import { fetchTrafficVolumeFeature, getCachedTrafficVolumeFeature } from "@/lib/trafficVolumes";
+
+type TrafficVolumeInfoTooltipProps = {
+  trafficVolumeId?: string | null;
+  children: React.ReactNode;
+  className?: string;
+  tooltipClassName?: string;
+};
+
+type TooltipStatus = "idle" | "loading" | "ready" | "error";
+
+function normalizeId(id?: string | null): string {
+  if (!id) return "";
+  return String(id).trim();
+}
+
+function formatFlightLevel(fl: unknown): string | null {
+  const num = Number(fl);
+  if (!Number.isFinite(num)) return null;
+  const rounded = Math.round(num);
+  return `FL${rounded.toString().padStart(3, "0")}`;
+}
+
+export default function TrafficVolumeInfoTooltip({
+  trafficVolumeId,
+  children,
+  className,
+  tooltipClassName,
+}: TrafficVolumeInfoTooltipProps) {
+  const normalizedId = useMemo(() => normalizeId(trafficVolumeId), [trafficVolumeId]);
+  const cached = useMemo(() => (normalizedId ? getCachedTrafficVolumeFeature(normalizedId)?.properties ?? null : null), [normalizedId]);
+
+  const [status, setStatus] = useState<TooltipStatus>(() => {
+    if (!normalizedId) return "idle";
+    if (cached) return "ready";
+    return "loading";
+  });
+  const [meta, setMeta] = useState<SectorFeatureProps | null>(() => cached);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (!normalizedId) {
+      setStatus("idle");
+      setMeta(null);
+      setError(null);
+      return;
+    }
+
+    const cachedProps = getCachedTrafficVolumeFeature(normalizedId)?.properties ?? null;
+    if (cachedProps) {
+      setMeta(cachedProps);
+      setStatus("ready");
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setStatus("loading");
+    setError(null);
+
+    fetchTrafficVolumeFeature(normalizedId)
+      .then((feature) => {
+        if (cancelled) return;
+        if (feature?.properties) {
+          setMeta(feature.properties);
+          setStatus("ready");
+        } else {
+          setMeta(null);
+          setStatus("error");
+          setError("Traffic volume not found");
+        }
+      })
+      .catch((err: any) => {
+        if (cancelled) return;
+        setMeta(null);
+        setStatus("error");
+        setError(err?.message || "Failed to load traffic volume");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [normalizedId]);
+
+  const handleOpen = () => {
+    if (!normalizedId) return;
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  if (!normalizedId) {
+    return <>{children}</>;
+  }
+
+  const rootClassName = [
+    "relative inline-flex min-w-0 max-w-full items-center",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const tooltipClass = [
+    "pointer-events-none absolute left-1/2 top-full z-50 -translate-x-1/2 translate-y-2 whitespace-nowrap rounded-lg border border-white/15 bg-slate-950/95 px-3 py-2 text-[11px] text-white/90 shadow-xl transition-opacity duration-150",
+    open ? "opacity-100" : "opacity-0",
+    open ? "visible" : "invisible",
+    tooltipClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const formattedMin = formatFlightLevel(meta?.min_fl);
+  const formattedMax = formatFlightLevel(meta?.max_fl);
+  const showRange = formattedMin && formattedMax;
+
+  return (
+    <span
+      className={rootClassName}
+      onMouseEnter={handleOpen}
+      onMouseLeave={handleClose}
+      onFocusCapture={handleOpen}
+      onBlurCapture={handleClose}
+    >
+      <span className="min-w-0 max-w-full">{children}</span>
+      <span className={tooltipClass} role="status" aria-live="polite">
+        <span className="flex min-w-0 max-w-xs flex-col text-left">
+          <span className="text-xs font-semibold text-white">{meta?.name?.trim() || normalizedId}</span>
+          <span className="font-mono text-[11px] tracking-wide text-white/70">{normalizedId}</span>
+          {status === "loading" && <span className="mt-1 text-white/60">Loading…</span>}
+          {status === "error" && <span className="mt-1 text-rose-300">{error || "Not available"}</span>}
+          {status === "ready" && showRange && (
+            <span className="mt-1 text-emerald-300">
+              {formattedMin} – {formattedMax}
+            </span>
+          )}
+        </span>
+      </span>
+    </span>
+  );
+}

--- a/src/components/TrafficVolumeMiniMap.tsx
+++ b/src/components/TrafficVolumeMiniMap.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import maplibregl, { LngLatBoundsLike } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+
+import { createMapStyle } from "@/lib/mapStyle";
+import { useThemeStore } from "./useThemeStore";
+import { fetchTrafficVolumeFeature, getCachedTrafficVolumeFeature } from "@/lib/trafficVolumes";
+import type { TrafficVolumeFeature } from "@/lib/trafficVolumes";
+
+const SOURCE_ID = "mini-traffic-volume";
+const FILL_LAYER_ID = "mini-traffic-volume-fill";
+const OUTLINE_LAYER_ID = "mini-traffic-volume-outline";
+
+const EMPTY_COLLECTION: GeoJSON.FeatureCollection = {
+  type: "FeatureCollection",
+  features: [],
+};
+
+function normalizeId(id?: string | null): string {
+  if (!id) return "";
+  return String(id).trim();
+}
+
+function collectCoordinates(geometry: GeoJSON.Geometry | null | undefined): [number, number][] {
+  if (!geometry) return [];
+  const coords: [number, number][] = [];
+
+  const pushCoords = (value: any) => {
+    if (!Array.isArray(value)) return;
+    if (typeof value[0] === "number" && typeof value[1] === "number") {
+      coords.push([Number(value[0]), Number(value[1])]);
+      return;
+    }
+    for (const nested of value) {
+      pushCoords(nested);
+    }
+  };
+
+  switch (geometry.type) {
+    case "Point":
+      pushCoords(geometry.coordinates);
+      break;
+    case "MultiPoint":
+    case "LineString":
+    case "MultiLineString":
+    case "Polygon":
+    case "MultiPolygon":
+      pushCoords(geometry.coordinates);
+      break;
+    default:
+      break;
+  }
+
+  return coords.filter(([lon, lat]) => Number.isFinite(lon) && Number.isFinite(lat));
+}
+
+function computeBounds(feature: TrafficVolumeFeature | null): LngLatBoundsLike | null {
+  if (!feature || !feature.geometry) return null;
+  const coords = collectCoordinates(feature.geometry);
+  if (coords.length === 0) return null;
+  let minLon = Number.POSITIVE_INFINITY;
+  let minLat = Number.POSITIVE_INFINITY;
+  let maxLon = Number.NEGATIVE_INFINITY;
+  let maxLat = Number.NEGATIVE_INFINITY;
+  for (const [lon, lat] of coords) {
+    if (lon < minLon) minLon = lon;
+    if (lat < minLat) minLat = lat;
+    if (lon > maxLon) maxLon = lon;
+    if (lat > maxLat) maxLat = lat;
+  }
+  if (!Number.isFinite(minLon) || !Number.isFinite(maxLon) || !Number.isFinite(minLat) || !Number.isFinite(maxLat)) {
+    return null;
+  }
+
+  const deltaLon = Math.abs(maxLon - minLon);
+  const deltaLat = Math.abs(maxLat - minLat);
+  const isSinglePoint = deltaLon < 1e-5 && deltaLat < 1e-5;
+
+  if (isSinglePoint) {
+    const padding = 0.5;
+    return [
+      [minLon - padding, minLat - padding],
+      [maxLon + padding, maxLat + padding],
+    ];
+  }
+
+  return [
+    [minLon, minLat],
+    [maxLon, maxLat],
+  ];
+}
+
+interface TrafficVolumeMiniMapProps {
+  trafficVolumeId?: string | null;
+  className?: string;
+}
+
+export default function TrafficVolumeMiniMap({ trafficVolumeId, className }: TrafficVolumeMiniMapProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<maplibregl.Map | null>(null);
+  const [mapReady, setMapReady] = useState(false);
+  const [loadingFeature, setLoadingFeature] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [feature, setFeature] = useState<TrafficVolumeFeature | null>(() => {
+    const normalized = normalizeId(trafficVolumeId);
+    if (!normalized) return null;
+    return getCachedTrafficVolumeFeature(normalized);
+  });
+
+  const theme = useThemeStore((state) => state.theme);
+
+  const normalizedId = useMemo(() => normalizeId(trafficVolumeId), [trafficVolumeId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!normalizedId) {
+      setFeature(null);
+      setLoadError(null);
+      setLoadingFeature(false);
+      return () => { cancelled = true; };
+    }
+
+    const cached = getCachedTrafficVolumeFeature(normalizedId);
+    if (cached) {
+      setFeature(cached);
+      setLoadError(null);
+      setLoadingFeature(false);
+      return () => { cancelled = true; };
+    }
+
+    setLoadingFeature(true);
+    setLoadError(null);
+    fetchTrafficVolumeFeature(normalizedId)
+      .then((result) => {
+        if (cancelled) return;
+        setFeature(result ?? null);
+        if (!result) {
+          setLoadError("Traffic volume not found.");
+        }
+      })
+      .catch((err: any) => {
+        if (cancelled) return;
+        setFeature(null);
+        setLoadError(err?.message || "Failed to load traffic volume.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingFeature(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [normalizedId]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    setMapReady(false);
+
+    const map = new maplibregl.Map({
+      container: containerRef.current,
+      style: createMapStyle(theme, 512),
+      center: [3, 45],
+      zoom: 4,
+      attributionControl: false,
+      interactive: false,
+      renderWorldCopies: false,
+    });
+
+    mapRef.current = map;
+
+    const handleLoad = () => {
+      setMapReady(true);
+      map.resize();
+    };
+
+    map.on("load", handleLoad);
+
+    return () => {
+      map.off("load", handleLoad);
+      map.remove();
+      mapRef.current = null;
+    };
+  }, [theme]);
+
+  const featureCollection = useMemo(() => {
+    if (!feature) return EMPTY_COLLECTION;
+    return {
+      type: "FeatureCollection",
+      features: [feature],
+    } as GeoJSON.FeatureCollection;
+  }, [feature]);
+
+  const bounds = useMemo(() => computeBounds(feature), [feature]);
+  const hasFeature = Boolean(feature);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !mapReady) return;
+
+    if (!map.getSource(SOURCE_ID)) {
+      map.addSource(SOURCE_ID, {
+        type: "geojson",
+        data: featureCollection,
+      });
+    }
+
+    const source = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
+    source?.setData(featureCollection);
+
+    if (!map.getLayer(FILL_LAYER_ID)) {
+      map.addLayer({
+        id: FILL_LAYER_ID,
+        type: "fill",
+        source: SOURCE_ID,
+        paint: {
+          "fill-color": "#38bdf8",
+          "fill-opacity": 0.3,
+        },
+      });
+    }
+
+    if (!map.getLayer(OUTLINE_LAYER_ID)) {
+      map.addLayer(
+        {
+          id: OUTLINE_LAYER_ID,
+          type: "line",
+          source: SOURCE_ID,
+          paint: {
+            "line-color": "#38bdf8",
+            "line-width": 2.5,
+            "line-opacity": 0.85,
+          },
+        },
+        FILL_LAYER_ID,
+      );
+    }
+
+    if (hasFeature && bounds) {
+      map.fitBounds(bounds, {
+        padding: 28,
+        duration: 0,
+        maxZoom: 7,
+      });
+    } else if (!hasFeature) {
+      map.easeTo({ center: [3, 45], zoom: 3.5, duration: 0 });
+    }
+  }, [featureCollection, hasFeature, bounds, mapReady]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!mapReady || !map || !containerRef.current) return;
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() => {
+      map.resize();
+    });
+
+    observer.observe(containerRef.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [mapReady]);
+
+  const rootClassName = ["relative h-full w-full", className].filter(Boolean).join(" ");
+
+  const showNoSelection = !normalizedId;
+  const showLoading = normalizedId && loadingFeature;
+  const showMissing = normalizedId && !loadingFeature && !hasFeature;
+
+  return (
+    <div className={rootClassName}>
+      <div ref={containerRef} className="absolute inset-0" />
+      {!mapReady && (
+        <div className="absolute inset-0 flex items-center justify-center bg-slate-950/60 text-xs text-white/60">
+          Loading map…
+        </div>
+      )}
+      {mapReady && showNoSelection && (
+        <div className="absolute inset-0 flex items-center justify-center bg-slate-950/60 text-xs text-white/60">
+          Select a traffic volume to preview
+        </div>
+      )}
+      {mapReady && showLoading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-slate-950/60 text-xs text-white/60">
+          Loading traffic volume…
+        </div>
+      )}
+      {mapReady && showMissing && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 bg-slate-950/60 text-center text-xs text-rose-200">
+          <span>Traffic volume not found.</span>
+          {loadError && <span className="text-[11px] text-rose-300/80">{loadError}</span>}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/trafficVolumes.ts
+++ b/src/lib/trafficVolumes.ts
@@ -1,0 +1,108 @@
+import { loadSectors } from "./airspace";
+import type { SectorFeatureProps } from "./models";
+
+export type TrafficVolumeFeature = GeoJSON.Feature<GeoJSON.Geometry, SectorFeatureProps>;
+
+const TRAFFIC_VOLUME_URL_CANDIDATES = ["/data/airspace.geojson", "/data/airspace.json"] as const;
+
+let trafficVolumeFeatureCollection: GeoJSON.FeatureCollection | null = null;
+let trafficVolumeFeatureMap: Map<string, TrafficVolumeFeature> | null = null;
+let trafficVolumeLoadPromise: Promise<Map<string, TrafficVolumeFeature>> | null = null;
+
+function normalizeTrafficVolumeId(id: string | null | undefined): string {
+  if (!id) return "";
+  return String(id).trim();
+}
+
+function buildFeatureMap(collection: GeoJSON.FeatureCollection): Map<string, TrafficVolumeFeature> {
+  const map = new Map<string, TrafficVolumeFeature>();
+  if (!collection || !Array.isArray(collection.features)) return map;
+
+  for (const feature of collection.features) {
+    if (!feature || typeof feature !== "object") continue;
+    const properties = (feature as TrafficVolumeFeature)?.properties;
+    const rawId = normalizeTrafficVolumeId(properties?.traffic_volume_id as string | null | undefined);
+    if (!rawId) continue;
+    map.set(rawId, feature as TrafficVolumeFeature);
+  }
+
+  return map;
+}
+
+async function loadTrafficVolumeCollection(): Promise<GeoJSON.FeatureCollection> {
+  let lastError: unknown = null;
+  for (const url of TRAFFIC_VOLUME_URL_CANDIDATES) {
+    try {
+      const collection = await loadSectors(url);
+      if (collection && collection.type === "FeatureCollection") {
+        return collection as GeoJSON.FeatureCollection;
+      }
+    } catch (err) {
+      lastError = err;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  throw new Error("Failed to load traffic volume definitions.");
+}
+
+async function ensureTrafficVolumeMap(): Promise<Map<string, TrafficVolumeFeature>> {
+  if (trafficVolumeFeatureMap) {
+    return trafficVolumeFeatureMap;
+  }
+
+  if (!trafficVolumeLoadPromise) {
+    trafficVolumeLoadPromise = (async () => {
+      const collection = await loadTrafficVolumeCollection();
+      trafficVolumeFeatureCollection = collection;
+      const map = buildFeatureMap(collection);
+      trafficVolumeFeatureMap = map;
+      return map;
+    })().catch((err) => {
+      trafficVolumeLoadPromise = null;
+      trafficVolumeFeatureCollection = null;
+      trafficVolumeFeatureMap = null;
+      throw err;
+    });
+  }
+
+  return trafficVolumeLoadPromise;
+}
+
+export async function preloadTrafficVolumes(): Promise<void> {
+  await ensureTrafficVolumeMap();
+}
+
+export async function fetchTrafficVolumeFeature(id: string): Promise<TrafficVolumeFeature | null> {
+  const normalized = normalizeTrafficVolumeId(id);
+  if (!normalized) return null;
+  const map = await ensureTrafficVolumeMap();
+  return map.get(normalized) ?? null;
+}
+
+export function getCachedTrafficVolumeFeature(id: string): TrafficVolumeFeature | null {
+  const normalized = normalizeTrafficVolumeId(id);
+  if (!normalized || !trafficVolumeFeatureMap) return null;
+  return trafficVolumeFeatureMap.get(normalized) ?? null;
+}
+
+export async function fetchTrafficVolumeProperties(id: string): Promise<SectorFeatureProps | null> {
+  const feature = await fetchTrafficVolumeFeature(id);
+  return feature?.properties ?? null;
+}
+
+export function getCachedTrafficVolumeProperties(id: string): SectorFeatureProps | null {
+  return getCachedTrafficVolumeFeature(id)?.properties ?? null;
+}
+
+export function listTrafficVolumeIdsSync(): string[] | null {
+  if (!trafficVolumeFeatureMap) return null;
+  return Array.from(trafficVolumeFeatureMap.keys());
+}
+
+export function getTrafficVolumeFeatureCollectionSync(): GeoJSON.FeatureCollection | null {
+  return trafficVolumeFeatureCollection;
+}


### PR DESCRIPTION
## Summary
- add a reusable traffic volume metadata loader and mini map component
- implement a tooltip that displays traffic volume details and use it for occupancy chart titles across analytics views
- enhance occupancy-related UIs with consistent traffic volume context on hover

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7ef2174d8832ba58809f577675bc5