### PR TITLE
Add relative change sorting for occupancy rankings

### DIFF
--- a/src/app/flow-evaluation/page.tsx
+++ b/src/app/flow-evaluation/page.tsx
@@ -136,7 +136,7 @@ function FlowEvaluationPageContent() {
   // Occupancy Flow/Total-Pre TV sort mode
   const [occOrigSortMode, setOccOrigSortMode] = useState<'total' | 'flow_absolute' | 'flow_relative' | 'exceedance'>("total");
   // Occupancy Pre-Post TV sort mode
-  const [occAllSortMode, setOccAllSortMode] = useState<'total' | 'abs_change' | 'exceedance'>("total");
+  const [occAllSortMode, setOccAllSortMode] = useState<'total' | 'abs_change' | 'relative_change' | 'exceedance'>("total");
   const [snapshotPromptOpen, setSnapshotPromptOpen] = useState(false);
   const [snapshotDescription, setSnapshotDescription] = useState("");
   const [snapshotSaving, setSnapshotSaving] = useState(false);
@@ -276,6 +276,14 @@ function FlowEvaluationPageContent() {
 
   const selectedTvSet = useMemo(() => new Set(selectedTrafficVolumes.map(String)), [selectedTrafficVolumes]);
   const hasTvFilter = selectedTrafficVolumes.length > 0;
+
+  const canRankOccAllChanges = useMemo(() => {
+    const pre = occAllState.data?.pre_counts || {};
+    const post = occAllState.data?.post_counts || {};
+    const hasPre = Object.values(pre).some((series) => Array.isArray(series) && series.length > 0);
+    const hasPost = Object.values(post).some((series) => Array.isArray(series) && series.length > 0);
+    return hasPre && hasPost;
+  }, [occAllState.data?.pre_counts, occAllState.data?.post_counts]);
 
   const occAllPostCountsForView = useMemo<Record<string, number[]>>(() => {
     const src = occAllState.data?.post_counts;
@@ -745,6 +753,25 @@ function FlowEvaluationPageContent() {
           const aa = Number.isFinite(a) ? a : 0;
           const bb = Number.isFinite(b) ? b : 0;
           score += Math.abs(bb - aa);
+        }
+      } else if (occAllSortMode === 'relative_change') {
+        const n = Math.min(A.length, B.length);
+        let deltaSum = 0;
+        let baseSum = 0;
+        for (let i = 0; i < n; i++) {
+          const startMin = i * minutes;
+          if (startMin < vFrom || startMin > vTo) continue;
+          const a = Number(A[i] ?? 0);
+          const b = Number(B[i] ?? 0);
+          const aa = Number.isFinite(a) ? a : 0;
+          const bb = Number.isFinite(b) ? b : 0;
+          deltaSum += Math.abs(bb - aa);
+          baseSum += Math.abs(aa);
+        }
+        if (baseSum > 0) {
+          score = deltaSum / baseSum;
+        } else {
+          score = deltaSum > 0 ? Number.MAX_SAFE_INTEGER : 0;
         }
       } else {
         // exceedance: sum of positive (demand - capacity) over in-view bins using post if available else pre
@@ -1338,10 +1365,17 @@ function FlowEvaluationPageContent() {
                       <option value="total">Rank by Total</option>
                       <option
                         value="abs_change"
-                        disabled={!occAllState.data?.post_counts}
-                        title={!occAllState.data?.post_counts ? 'Run optimization to get post counts for changes.' : undefined}
+                        disabled={!canRankOccAllChanges}
+                        title={!canRankOccAllChanges ? 'Run optimization to compare pre and post counts.' : undefined}
                       >
                         Rank by Absolute Changes (Pre vs Post)
+                      </option>
+                      <option
+                        value="relative_change"
+                        disabled={!canRankOccAllChanges}
+                        title={!canRankOccAllChanges ? 'Run optimization to compare pre and post counts.' : undefined}
+                      >
+                        Rank by Relative Changes (Pre vs Post)
                       </option>
                       <option value="exceedance">By Exceedances</option>
                     </select>

--- a/src/app/regulation-comparison/page.tsx
+++ b/src/app/regulation-comparison/page.tsx
@@ -30,13 +30,25 @@ import { ResponsiveContainer, ComposedChart, CartesianGrid, XAxis, YAxis, Toolti
 
 const PALETTE = ["#38bdf8", "#f472b6", "#facc15", "#34d399"];
 const ABS_CHANGE_PREFIX = "abs_change:" as const;
+const REL_CHANGE_PREFIX = "rel_change:" as const;
 
 type FlightSortMode = "max" | "diff" | "callsign";
-type TvSortMode = "exceedance" | "peak" | "alphabetical" | `${typeof ABS_CHANGE_PREFIX}${string}`;
+type TvSortMode =
+  | "exceedance"
+  | "peak"
+  | "alphabetical"
+  | `${typeof ABS_CHANGE_PREFIX}${string}`
+  | `${typeof REL_CHANGE_PREFIX}${string}`;
 
-function getAbsChangeSnapshotId(mode: TvSortMode): string | null {
-  return mode.startsWith(ABS_CHANGE_PREFIX) ? mode.slice(ABS_CHANGE_PREFIX.length) : null;
+function getPrefixedSnapshotId(
+  mode: TvSortMode,
+  prefix: typeof ABS_CHANGE_PREFIX | typeof REL_CHANGE_PREFIX,
+): string | null {
+  return mode.startsWith(prefix) ? mode.slice(prefix.length) : null;
 }
+
+const getAbsChangeSnapshotId = (mode: TvSortMode) => getPrefixedSnapshotId(mode, ABS_CHANGE_PREFIX);
+const getRelativeChangeSnapshotId = (mode: TvSortMode) => getPrefixedSnapshotId(mode, REL_CHANGE_PREFIX);
 
 type FlightRow = {
   flightId: string;
@@ -55,7 +67,7 @@ type TvMetrics = {
   maxPeak: number;
 };
 
-type AbsChangeSortOption = {
+type ChangeSortOption = {
   value: TvSortMode;
   label: string;
   disabled: boolean;
@@ -782,7 +794,54 @@ export default function RegulationComparisonPage() {
     return map;
   }, [alignedSnapshots, minutesPerBin, viewFromMin, viewToMin]);
 
-  const absChangeSortOptions = useMemo<AbsChangeSortOption[]>(() => {
+  const tvRelativeChangeBySnapshot = useMemo(() => {
+    const map = new Map<string, Record<string, number>>();
+    alignedSnapshots.forEach((snap) => {
+      const aggregated = snap.aggregatedRolling;
+      if (!aggregated) {
+        map.set(snap.id, {});
+        return;
+      }
+      const pre = aggregated.pre_counts || {};
+      const post = aggregated.post_counts || {};
+      const tvIds = new Set<string>([
+        ...Object.keys(pre || {}),
+        ...Object.keys(post || {}),
+      ]);
+      const entries: Record<string, number> = {};
+      if (tvIds.size === 0) {
+        map.set(snap.id, entries);
+        return;
+      }
+      const minutes = Number(aggregated.time_bin_minutes || minutesPerBin || snap.minutesPerBin || 15);
+      tvIds.forEach((tvId) => {
+        const preSeries = pre?.[tvId] || [];
+        const postSeries = post?.[tvId] || [];
+        const n = Math.min(preSeries.length, postSeries.length);
+        let deltaSum = 0;
+        let baseSum = 0;
+        for (let i = 0; i < n; i++) {
+          const start = i * minutes;
+          if (start < viewFromMin || start > viewToMin) continue;
+          const a = Number(preSeries[i] ?? 0);
+          const b = Number(postSeries[i] ?? 0);
+          const aa = Number.isFinite(a) ? a : 0;
+          const bb = Number.isFinite(b) ? b : 0;
+          deltaSum += Math.abs(bb - aa);
+          baseSum += Math.abs(aa);
+        }
+        if (baseSum > 0) {
+          entries[tvId] = deltaSum / baseSum;
+        } else {
+          entries[tvId] = deltaSum > 0 ? Number.MAX_SAFE_INTEGER : 0;
+        }
+      });
+      map.set(snap.id, entries);
+    });
+    return map;
+  }, [alignedSnapshots, minutesPerBin, viewFromMin, viewToMin]);
+
+  const absChangeSortOptions = useMemo<ChangeSortOption[]>(() => {
     return alignedSnapshots.map((snap) => {
       const aggregated = snap.aggregatedRolling;
       const preCount = Object.keys(aggregated?.pre_counts || {}).length;
@@ -806,14 +865,46 @@ export default function RegulationComparisonPage() {
     });
   }, [alignedSnapshots]);
 
+  const relativeChangeSortOptions = useMemo<ChangeSortOption[]>(() => {
+    return alignedSnapshots.map((snap) => {
+      const aggregated = snap.aggregatedRolling;
+      const preCount = Object.keys(aggregated?.pre_counts || {}).length;
+      const postCount = Object.keys(aggregated?.post_counts || {}).length;
+      let disabled = false;
+      let reason: string | undefined;
+      if (!aggregated || postCount === 0) {
+        disabled = true;
+        reason = "Snapshot is missing post-rolling counts.";
+      } else if (preCount === 0) {
+        disabled = true;
+        reason = "Snapshot is missing baseline rolling counts.";
+      }
+      return {
+        value: `${REL_CHANGE_PREFIX}${snap.id}` as TvSortMode,
+        label: `Rank by Relative Change (${snap.description || "Untitled"})`,
+        disabled,
+        reason,
+        snapshotId: snap.id,
+      };
+    });
+  }, [alignedSnapshots]);
+
   useEffect(() => {
-    const snapshotId = getAbsChangeSnapshotId(tvSort);
-    if (!snapshotId) return;
-    const option = absChangeSortOptions.find((opt) => opt.snapshotId === snapshotId);
+    const absSnapshotId = getAbsChangeSnapshotId(tvSort);
+    if (absSnapshotId) {
+      const option = absChangeSortOptions.find((opt) => opt.snapshotId === absSnapshotId);
+      if (!option || option.disabled) {
+        if (tvSort !== "exceedance") setTvSort("exceedance");
+      }
+      return;
+    }
+    const relSnapshotId = getRelativeChangeSnapshotId(tvSort);
+    if (!relSnapshotId) return;
+    const option = relativeChangeSortOptions.find((opt) => opt.snapshotId === relSnapshotId);
     if (!option || option.disabled) {
       if (tvSort !== "exceedance") setTvSort("exceedance");
     }
-  }, [absChangeSortOptions, tvSort]);
+  }, [absChangeSortOptions, relativeChangeSortOptions, tvSort]);
 
   const filteredTvIds = useMemo(() => {
     let list = tvMetrics;
@@ -822,6 +913,8 @@ export default function RegulationComparisonPage() {
     }
     const absChangeSnapshotId = getAbsChangeSnapshotId(tvSort);
     const absScores = absChangeSnapshotId ? tvAbsChangeBySnapshot.get(absChangeSnapshotId) || null : null;
+    const relChangeSnapshotId = getRelativeChangeSnapshotId(tvSort);
+    const relScores = relChangeSnapshotId ? tvRelativeChangeBySnapshot.get(relChangeSnapshotId) || null : null;
     const collator = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
     const sorted = [...list];
     sorted.sort((a, b) => {
@@ -829,6 +922,16 @@ export default function RegulationComparisonPage() {
         const scoreA = absScores[a.tvId] ?? 0;
         const scoreB = absScores[b.tvId] ?? 0;
         if (scoreB !== scoreA) return scoreB - scoreA;
+        return collator.compare(a.tvId, b.tvId);
+      }
+      if (relScores) {
+        const scoreA = relScores[a.tvId] ?? 0;
+        const scoreB = relScores[b.tvId] ?? 0;
+        if (scoreB !== scoreA) return scoreB - scoreA;
+        const absMap = relChangeSnapshotId ? tvAbsChangeBySnapshot.get(relChangeSnapshotId) || {} : {};
+        const absA = absMap[a.tvId] ?? 0;
+        const absB = absMap[b.tvId] ?? 0;
+        if (absB !== absA) return absB - absA;
         return collator.compare(a.tvId, b.tvId);
       }
       if (tvSort === "alphabetical") {
@@ -842,7 +945,14 @@ export default function RegulationComparisonPage() {
       return b.maxPeak - a.maxPeak;
     });
     return sorted.map((item) => item.tvId);
-  }, [tvMetrics, hasTvFilter, selectedTvSet, tvSort, tvAbsChangeBySnapshot]);
+  }, [
+    tvMetrics,
+    hasTvFilter,
+    selectedTvSet,
+    tvSort,
+    tvAbsChangeBySnapshot,
+    tvRelativeChangeBySnapshot,
+  ]);
 
   const visibleTvs = filteredTvIds.slice(0, visibleTvCount);
   const remainingTvCount = Math.max(0, filteredTvIds.length - visibleTvCount);
@@ -1454,6 +1564,16 @@ export default function RegulationComparisonPage() {
                   <option value="peak">Sort by peak</option>
                   <option value="alphabetical">Sort alphabetically</option>
                   {absChangeSortOptions.map((option) => (
+                    <option
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      title={option.reason}
+                    >
+                      {option.label}
+                    </option>
+                  ))}
+                  {relativeChangeSortOptions.map((option) => (
                     <option
                       key={option.value}
                       value={option.value}

--- a/src/app/solution-comparison/page.tsx
+++ b/src/app/solution-comparison/page.tsx
@@ -30,14 +30,26 @@ import { ResponsiveContainer, ComposedChart, CartesianGrid, XAxis, YAxis, Toolti
 
 const PALETTE = ["#38bdf8", "#f472b6", "#facc15", "#34d399"];
 const ABS_CHANGE_PREFIX = "abs_change:" as const;
+const REL_CHANGE_PREFIX = "rel_change:" as const;
 
 type OccupancyScope = "aggregate" | "targets" | "ripples";
 type FlightSortMode = "max" | "diff" | "callsign";
-type TvSortMode = "exceedance" | "peak" | "alphabetical" | `${typeof ABS_CHANGE_PREFIX}${string}`;
+type TvSortMode =
+  | "exceedance"
+  | "peak"
+  | "alphabetical"
+  | `${typeof ABS_CHANGE_PREFIX}${string}`
+  | `${typeof REL_CHANGE_PREFIX}${string}`;
 
-function getAbsChangeSnapshotId(mode: TvSortMode): string | null {
-  return mode.startsWith(ABS_CHANGE_PREFIX) ? mode.slice(ABS_CHANGE_PREFIX.length) : null;
+function getPrefixedSnapshotId(
+  mode: TvSortMode,
+  prefix: typeof ABS_CHANGE_PREFIX | typeof REL_CHANGE_PREFIX,
+): string | null {
+  return mode.startsWith(prefix) ? mode.slice(prefix.length) : null;
 }
+
+const getAbsChangeSnapshotId = (mode: TvSortMode) => getPrefixedSnapshotId(mode, ABS_CHANGE_PREFIX);
+const getRelativeChangeSnapshotId = (mode: TvSortMode) => getPrefixedSnapshotId(mode, REL_CHANGE_PREFIX);
 
 type FlightRow = {
   flightId: string;
@@ -56,7 +68,7 @@ type TvMetrics = {
   maxPeak: number;
 };
 
-type AbsChangeSortOption = {
+type ChangeSortOption = {
   value: TvSortMode;
   label: string;
   disabled: boolean;
@@ -811,7 +823,55 @@ export default function SolutionComparisonPage() {
     return map;
   }, [alignedSnapshots, minutesPerBin, tvScope, viewFromMin, viewToMin]);
 
-  const absChangeSortOptions = useMemo<AbsChangeSortOption[]>(() => {
+  const tvRelativeChangeBySnapshot = useMemo(() => {
+    const map = new Map<string, Record<string, number>>();
+    if (tvScope !== "aggregate") return map;
+    alignedSnapshots.forEach((snap) => {
+      const occ = snap.aggregatedOccupancy;
+      if (!occ) {
+        map.set(snap.id, {});
+        return;
+      }
+      const pre = occ.pre_counts || {};
+      const post = occ.post_counts || {};
+      const tvIds = new Set<string>([
+        ...Object.keys(pre || {}),
+        ...Object.keys(post || {}),
+      ]);
+      const entries: Record<string, number> = {};
+      if (tvIds.size === 0) {
+        map.set(snap.id, entries);
+        return;
+      }
+      const minutes = Number(occ.time_bin_minutes || minutesPerBin || snap.minutesPerBin || 15);
+      tvIds.forEach((tvId) => {
+        const preSeries = pre?.[tvId] || [];
+        const postSeries = post?.[tvId] || [];
+        const n = Math.min(preSeries.length, postSeries.length);
+        let deltaSum = 0;
+        let baseSum = 0;
+        for (let i = 0; i < n; i++) {
+          const start = i * minutes;
+          if (start < viewFromMin || start > viewToMin) continue;
+          const a = Number(preSeries[i] ?? 0);
+          const b = Number(postSeries[i] ?? 0);
+          const aa = Number.isFinite(a) ? a : 0;
+          const bb = Number.isFinite(b) ? b : 0;
+          deltaSum += Math.abs(bb - aa);
+          baseSum += Math.abs(aa);
+        }
+        if (baseSum > 0) {
+          entries[tvId] = deltaSum / baseSum;
+        } else {
+          entries[tvId] = deltaSum > 0 ? Number.MAX_SAFE_INTEGER : 0;
+        }
+      });
+      map.set(snap.id, entries);
+    });
+    return map;
+  }, [alignedSnapshots, minutesPerBin, tvScope, viewFromMin, viewToMin]);
+
+  const absChangeSortOptions = useMemo<ChangeSortOption[]>(() => {
     if (tvScope !== "aggregate") return [];
     return alignedSnapshots.map((snap) => {
       const occ = snap.aggregatedOccupancy;
@@ -839,6 +899,31 @@ export default function SolutionComparisonPage() {
     });
   }, [alignedSnapshots, tvScope]);
 
+  const relativeChangeSortOptions = useMemo<ChangeSortOption[]>(() => {
+    if (tvScope !== "aggregate") return [];
+    return alignedSnapshots.map((snap) => {
+      const occ = snap.aggregatedOccupancy;
+      const preCount = Object.keys(occ?.pre_counts || {}).length;
+      const postCount = Object.keys(occ?.post_counts || {}).length;
+      let disabled = false;
+      let reason: string | undefined;
+      if (!occ || postCount === 0) {
+        disabled = true;
+        reason = "Snapshot is missing post-optimization aggregate counts.";
+      } else if (preCount === 0) {
+        disabled = true;
+        reason = "Snapshot is missing baseline aggregate counts.";
+      }
+      return {
+        value: `${REL_CHANGE_PREFIX}${snap.id}` as TvSortMode,
+        label: `Rank by Relative Change (${snap.description || "Untitled"})`,
+        disabled,
+        reason,
+        snapshotId: snap.id,
+      };
+    });
+  }, [alignedSnapshots, tvScope]);
+
   useEffect(() => {
     const snapshotId = getAbsChangeSnapshotId(tvSort);
     if (!snapshotId) return;
@@ -852,6 +937,19 @@ export default function SolutionComparisonPage() {
     }
   }, [absChangeSortOptions, tvScope, tvSort]);
 
+  useEffect(() => {
+    const snapshotId = getRelativeChangeSnapshotId(tvSort);
+    if (!snapshotId) return;
+    if (tvScope !== "aggregate") {
+      if (tvSort !== "exceedance") setTvSort("exceedance");
+      return;
+    }
+    const option = relativeChangeSortOptions.find((opt) => opt.snapshotId === snapshotId);
+    if (!option || option.disabled) {
+      if (tvSort !== "exceedance") setTvSort("exceedance");
+    }
+  }, [relativeChangeSortOptions, tvScope, tvSort]);
+
   const filteredTvIds = useMemo(() => {
     let list = tvMetrics;
     if (hasTvFilter) {
@@ -859,6 +957,8 @@ export default function SolutionComparisonPage() {
     }
     const absChangeSnapshotId = getAbsChangeSnapshotId(tvSort);
     const absScores = absChangeSnapshotId ? (tvAbsChangeBySnapshot.get(absChangeSnapshotId) || null) : null;
+    const relChangeSnapshotId = getRelativeChangeSnapshotId(tvSort);
+    const relScores = relChangeSnapshotId ? (tvRelativeChangeBySnapshot.get(relChangeSnapshotId) || null) : null;
     const collator = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
     const sorted = [...list];
     sorted.sort((a, b) => {
@@ -866,6 +966,16 @@ export default function SolutionComparisonPage() {
         const scoreA = absScores[a.tvId] ?? 0;
         const scoreB = absScores[b.tvId] ?? 0;
         if (scoreB !== scoreA) return scoreB - scoreA;
+        return collator.compare(a.tvId, b.tvId);
+      }
+      if (relScores) {
+        const scoreA = relScores[a.tvId] ?? 0;
+        const scoreB = relScores[b.tvId] ?? 0;
+        if (scoreB !== scoreA) return scoreB - scoreA;
+        const absMap = relChangeSnapshotId ? tvAbsChangeBySnapshot.get(relChangeSnapshotId) || {} : {};
+        const absA = absMap[a.tvId] ?? 0;
+        const absB = absMap[b.tvId] ?? 0;
+        if (absB !== absA) return absB - absA;
         return collator.compare(a.tvId, b.tvId);
       }
       if (tvSort === "alphabetical") {
@@ -879,7 +989,14 @@ export default function SolutionComparisonPage() {
       return b.maxPeak - a.maxPeak;
     });
     return sorted.map((item) => item.tvId);
-  }, [tvMetrics, hasTvFilter, selectedTvSet, tvSort, tvAbsChangeBySnapshot]);
+  }, [
+    tvMetrics,
+    hasTvFilter,
+    selectedTvSet,
+    tvSort,
+    tvAbsChangeBySnapshot,
+    tvRelativeChangeBySnapshot,
+  ]);
 
   const visibleTvs = filteredTvIds.slice(0, visibleTvCount);
   const remainingTvCount = Math.max(0, filteredTvIds.length - visibleTvCount);
@@ -1555,6 +1672,16 @@ export default function SolutionComparisonPage() {
                   <option value="peak">Sort by peak</option>
                   <option value="alphabetical">Sort alphabetically</option>
                   {absChangeSortOptions.map((option) => (
+                    <option
+                      key={option.value}
+                      value={option.value}
+                      disabled={option.disabled}
+                      title={option.reason}
+                    >
+                      {option.label}
+                    </option>
+                  ))}
+                  {relativeChangeSortOptions.map((option) => (
                     <option
                       key={option.value}
                       value={option.value}

--- a/src/components/OccupancyPrePostPanel.tsx
+++ b/src/components/OccupancyPrePostPanel.tsx
@@ -6,7 +6,7 @@ import { formatSeeMoreLabel, SEE_LESS_LABEL } from "@/lib/seeMoreLess";
 import type { OccupancySeriesByTv } from "@/lib/models";
 import TrafficVolumeInfoTooltip from "./TrafficVolumeInfoTooltip";
 
-type SortMode = "total" | "abs_change" | "exceedance";
+type SortMode = "total" | "abs_change" | "relative_change" | "exceedance";
 
 export interface OccupancyPrePostPanelProps {
   postCounts: OccupancySeriesByTv;
@@ -176,6 +176,26 @@ export default function OccupancyPrePostPanel({
         const hasB = Array.isArray(postCounts?.[tv]) && (postCounts?.[tv] || []).length > 0;
         if (!hasA || !hasB) { s[tv] = 0; continue; }
         s[tv] = rows.reduce((acc, r) => acc + Math.abs((r.post || 0) - (r.pre || 0)), 0);
+      } else if (effectiveSort === 'relative_change') {
+        const hasA = Array.isArray(effectivePre?.[tv]) && (effectivePre?.[tv] || []).length > 0;
+        const hasB = Array.isArray(postCounts?.[tv]) && (postCounts?.[tv] || []).length > 0;
+        if (!hasA || !hasB) {
+          s[tv] = 0;
+          continue;
+        }
+        let deltaSum = 0;
+        let baseSum = 0;
+        for (const r of rows) {
+          const preVal = r.pre ?? 0;
+          const postVal = r.post ?? preVal;
+          deltaSum += Math.abs(postVal - preVal);
+          baseSum += Math.abs(preVal);
+        }
+        if (baseSum > 0) {
+          s[tv] = deltaSum / baseSum;
+        } else {
+          s[tv] = deltaSum > 0 ? Number.MAX_SAFE_INTEGER : 0;
+        }
       } else {
         // exceedance: sum positive (display - capacity) using display = post if available else pre
         const preferPost = Array.isArray(postCounts?.[tv]) && (postCounts?.[tv] || []).length > 0;

--- a/src/components/RegulationResults.tsx
+++ b/src/components/RegulationResults.tsx
@@ -125,7 +125,7 @@ export default function RegulationResults({ open, result, onClose }: RegulationR
   const regulations = useSimStore(s => s.regulations);
   const [viewFrom, setViewFrom] = useState<string>("00:00");
   const [viewTo, setViewTo] = useState<string>("23:59");
-  const [sortMode, setSortMode] = useState<'total' | 'abs_change' | 'exceedance'>("abs_change");
+  const [sortMode, setSortMode] = useState<'total' | 'abs_change' | 'relative_change' | 'exceedance'>("abs_change");
   const [regSnapshotPromptOpen, setRegSnapshotPromptOpen] = useState(false);
   const [regSnapshotDescription, setRegSnapshotDescription] = useState("");
   const [regSnapshotSaving, setRegSnapshotSaving] = useState(false);
@@ -500,6 +500,7 @@ export default function RegulationResults({ open, result, onClose }: RegulationR
                   >
                     <option value="total">Rank by Total</option>
                     <option value="abs_change" disabled={!hasBoth}>Rank by Absolute Changes</option>
+                    <option value="relative_change" disabled={!hasBoth}>Rank by Relative Changes</option>
                     <option value="exceedance" disabled={!hasCap}>By Exceedances</option>
                   </select>
                 );


### PR DESCRIPTION
## Summary
- add a relative change scoring mode to the aggregated pre/post occupancy charts in flow evaluation and regulation results
- extend the occupancy pre/post panel to compute relative change scores and expose the new option
- surface relative change ranking choices in regulation and solution comparison traffic volume lists

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8116fd580832b91ff520554bd8e97