### PR TITLE
Show regulation objective metrics in results and comparison

### DIFF
--- a/src/app/regulation-comparison/page.tsx
+++ b/src/app/regulation-comparison/page.tsx
@@ -126,6 +126,11 @@ function formatNumber(val: number | null | undefined, digits = 2) {
   return Number(val).toFixed(digits);
 }
 
+function toFiniteNumber(value: unknown): number | null {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
 function formatSecondsToHMM(totalSeconds: number | null | undefined): string {
   if (!Number.isFinite(totalSeconds ?? NaN)) return "—";
   const s = Math.max(0, Math.floor(totalSeconds as number));
@@ -402,6 +407,47 @@ export default function RegulationComparisonPage() {
       ...selectedSnapshots.map((snap) => snap.delayStats?.mean_delay_seconds ?? Number.POSITIVE_INFINITY),
     );
   }, [selectedSnapshots]);
+
+  const bestObjectiveScore = useMemo(() => {
+    const scores = selectedSnapshots
+      .map((snap) => toFiniteNumber(snap.objective?.score))
+      .filter((value): value is number => value !== null);
+    if (scores.length === 0) return null;
+    return Math.min(...scores);
+  }, [selectedSnapshots]);
+
+  const hasObjectiveScore = useMemo(
+    () => selectedSnapshots.some((snap) => toFiniteNumber(snap.objective?.score) !== null),
+    [selectedSnapshots],
+  );
+
+  const objectiveComponentKeys = useMemo(() => {
+    const keys = new Set<string>();
+    selectedSnapshots.forEach((snap) => {
+      const components = snap.objective?.components;
+      if (!components) return;
+      Object.keys(components).forEach((key) => keys.add(key));
+    });
+    return Array.from(keys).sort((a, b) => a.localeCompare(b));
+  }, [selectedSnapshots]);
+
+  const objectiveComponentBest = useMemo(() => {
+    const bestMap = new Map<string, number>();
+    objectiveComponentKeys.forEach((key) => {
+      let best: number | null = null;
+      selectedSnapshots.forEach((snap) => {
+        const value = toFiniteNumber(snap.objective?.components?.[key]);
+        if (value === null) return;
+        if (best === null || value < best) {
+          best = value;
+        }
+      });
+      if (best !== null) {
+        bestMap.set(key, best);
+      }
+    });
+    return bestMap;
+  }, [objectiveComponentKeys, selectedSnapshots]);
 
   const airportStatsBySnapshot = useMemo(() => {
     const map = new Map<string, SnapshotAirportStats>();
@@ -1123,6 +1169,78 @@ export default function RegulationComparisonPage() {
                 );
               })}
             </div>
+          </section>
+
+          <section className="bg-white/5 border border-white/10 rounded-xl p-4 mb-6">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold text-white">Objective comparison</h2>
+            </div>
+            {hasObjectiveScore || objectiveComponentKeys.length > 0 ? (
+              <>
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mt-4">
+                  {selectedSnapshots.map((snap) => {
+                    const color = colorBySnapshotId.get(snap.id) || "#fff";
+                    const score = toFiniteNumber(snap.objective?.score);
+                    const isBest = bestObjectiveScore !== null && score !== null && score === bestObjectiveScore;
+                    return (
+                      <div key={snap.id} className="rounded-lg border border-white/10 bg-white/5 p-4 text-white/80 space-y-2">
+                        <div className="flex items-center gap-2 text-sm font-semibold">
+                          <span className="inline-flex w-2 h-2 rounded-full" style={{ background: color }} />
+                          <span>{snap.description || "Untitled"}</span>
+                          {isBest && <span className="text-[10px] uppercase tracking-wider bg-emerald-500/20 border border-emerald-400/60 px-1.5 py-0.5 rounded text-emerald-100">Best</span>}
+                        </div>
+                        <div className="text-[12px] text-white/60">Objective score</div>
+                        <div className="text-2xl font-semibold text-white">{formatNumber(score, 2)}</div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                {objectiveComponentKeys.length > 0 && (
+                  <div className="mt-6 overflow-x-auto">
+                    <table className="min-w-full text-sm text-white/80">
+                      <thead className="text-white/60 text-[12px] uppercase tracking-wider">
+                        <tr>
+                          <th className="text-left px-3 py-2">Objective component</th>
+                          {selectedSnapshots.map((snap) => (
+                            <th key={snap.id} className="text-left px-3 py-2">
+                              <div className="flex items-center gap-2">
+                                <span className="inline-flex w-2 h-2 rounded-full" style={{ background: colorBySnapshotId.get(snap.id) || "#fff" }} />
+                                <span>{snap.description || "Untitled"}</span>
+                              </div>
+                            </th>
+                          ))}
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {objectiveComponentKeys.map((key) => {
+                          const bestValue = objectiveComponentBest.get(key);
+                          return (
+                            <tr key={key} className="border-t border-white/10">
+                              <td className="px-3 py-2 text-white/70">{key}</td>
+                              {selectedSnapshots.map((snap) => {
+                                const value = toFiniteNumber(snap.objective?.components?.[key]);
+                                const isBest = bestValue !== undefined && bestValue !== null && value !== null && value === bestValue;
+                                return (
+                                  <td
+                                    key={`${snap.id}-${key}`}
+                                    className={`px-3 py-2 font-mono text-[13px] ${isBest ? 'text-emerald-200' : 'text-white/80'}`}
+                                  >
+                                    {formatNumber(value, 3)}
+                                  </td>
+                                );
+                              })}
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="mt-4 text-sm text-white/60">Objective metrics not available for the selected snapshots.</div>
+            )}
           </section>
 
           <section className="bg-white/5 border border-white/10 rounded-xl p-4 mb-6">

--- a/src/components/RegulationResults.tsx
+++ b/src/components/RegulationResults.tsx
@@ -97,6 +97,11 @@ type AirportDelayChartRow = {
   totalFlights: number;
 };
 
+type ObjectiveComponentEntry = {
+  key: string;
+  value: number | null;
+};
+
 const toTrimmedString = (value: unknown): string => {
   if (typeof value === "string") {
     return value.trim();
@@ -395,6 +400,37 @@ export default function RegulationResults({ open, result, onClose }: RegulationR
 
   const regSnapshotCount = regSnapshotList.length;
 
+  const formatNumber = (value: number | null | undefined, digits = 2) => {
+    if (value === null || value === undefined) return "—";
+    if (!Number.isFinite(value)) return "∞";
+    return Number(value).toLocaleString(undefined, {
+      minimumFractionDigits: digits,
+      maximumFractionDigits: digits,
+    });
+  };
+
+  const objectiveScore = useMemo(() => {
+    if (!result) return null;
+    const score = Number(result.objective);
+    return Number.isFinite(score) ? score : null;
+  }, [result]);
+
+  const objectiveComponents = useMemo<ObjectiveComponentEntry[]>(() => {
+    const components = result?.objective_components;
+    if (!components || typeof components !== "object") return [];
+    return Object.entries(components)
+      .map(([key, value]) => {
+        const num = Number(value);
+        return {
+          key,
+          value: Number.isFinite(num) ? num : null,
+        };
+      })
+      .sort((a, b) => a.key.localeCompare(b.key));
+  }, [result?.objective_components]);
+
+  const hasObjectiveMetrics = objectiveScore !== null || objectiveComponents.length > 0;
+
   const handleOpenRegSnapshotPrompt = () => {
     if (!result) return;
     const current = loadRegSnapshots();
@@ -481,6 +517,42 @@ export default function RegulationResults({ open, result, onClose }: RegulationR
             <Stat label="Flights" value={`${ds.num_flights.toLocaleString()}`} />
           </div>
         </div>
+
+        {hasObjectiveMetrics && (
+          <div className="bg-white/5 border border-white/10 rounded-xl p-4">
+            <div className="flex flex-wrap items-center gap-3 mb-3">
+              <div className="text-sm uppercase tracking-wider text-gray-300">Objective Function</div>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              <Stat
+                label="Objective Score"
+                value={objectiveScore !== null ? formatNumber(objectiveScore, 2) : "—"}
+              />
+            </div>
+            {objectiveComponents.length > 0 && (
+              <div className="mt-4 overflow-x-auto">
+                <table className="min-w-full text-sm text-white/80">
+                  <thead className="text-white/60 text-[12px] uppercase tracking-wider">
+                    <tr>
+                      <th className="text-left px-3 py-2">Component</th>
+                      <th className="text-right px-3 py-2">Value</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {objectiveComponents.map((entry) => (
+                      <tr key={entry.key} className="border-t border-white/10">
+                        <td className="px-3 py-2 text-white/80">{entry.key}</td>
+                        <td className="px-3 py-2 text-right font-mono text-white/90">
+                          {formatNumber(entry.value ?? null, 3)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
 
         {/* Rolling-hour Occupancy Diff with time control and sort */}
         <div>

--- a/src/lib/reg-comparison.ts
+++ b/src/lib/reg-comparison.ts
@@ -14,6 +14,11 @@ export interface RegulationAggregatedRolling {
   timeLabels?: string[];
 }
 
+export interface RegulationObjectiveSummary {
+  score: number | null;
+  components?: Record<string, number>;
+}
+
 export interface RegulationSnapshot {
   version: number;
   id: string;
@@ -26,6 +31,29 @@ export interface RegulationSnapshot {
   delaysMin?: Record<string, number> | null;
   metadata?: Record<string, any> | null;
   shareUrl?: string | null;
+  objective?: RegulationObjectiveSummary | null;
+}
+
+function sanitizeObjective(raw: any): RegulationObjectiveSummary | null {
+  if (!raw || typeof raw !== "object") return null;
+  const scoreNumber = Number((raw as any).score);
+  const score = Number.isFinite(scoreNumber) ? scoreNumber : null;
+  let components: Record<string, number> | undefined;
+  const rawComponents = (raw as any).components;
+  if (rawComponents && typeof rawComponents === "object") {
+    const entries = Object.entries(rawComponents).reduce<Record<string, number>>((acc, [key, value]) => {
+      const num = Number(value);
+      if (Number.isFinite(num)) {
+        acc[key] = num;
+      }
+      return acc;
+    }, {});
+    if (Object.keys(entries).length > 0) {
+      components = entries;
+    }
+  }
+  if (score === null && !components) return null;
+  return { score, components };
 }
 
 function cloneSeries(values?: number[] | null): number[] {
@@ -105,6 +133,11 @@ export function createRegulationSnapshot(params: {
     delaysMin[String(flightId)] = minutes;
   });
 
+  const objective = sanitizeObjective({
+    score: result.objective,
+    components: result.objective_components,
+  });
+
   const snapshot: RegulationSnapshot = {
     version: REG_SNAPSHOT_VERSION,
     id,
@@ -117,6 +150,7 @@ export function createRegulationSnapshot(params: {
     delaysMin: Object.keys(delaysMin).length > 0 ? delaysMin : null,
     metadata: result.metadata ? { ...result.metadata } : null,
     shareUrl,
+    objective,
   };
 
   return snapshot;
@@ -141,10 +175,12 @@ function readRegSnapshotsFromStorage(): RegulationSnapshot[] {
           tv_ids_order: Array.isArray(aggregated.tv_ids_order) ? [...aggregated.tv_ids_order] : undefined,
           timeLabels: Array.isArray(aggregated.timeLabels) ? [...aggregated.timeLabels] : undefined,
         };
+        const sanitizedObjective = sanitizeObjective((item as any).objective);
         return {
           ...(item as any),
           version: typeof (item as any).version === "number" ? (item as any).version : REG_SNAPSHOT_VERSION,
           aggregatedRolling: sanitizedAggregated,
+          objective: sanitizedObjective,
         } as RegulationSnapshot;
       })
       .filter((item): item is RegulationSnapshot => !!item && !!item.id);
@@ -246,7 +282,7 @@ export function importRegSnapshots(raw: string): RegulationSnapshot[] {
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch (err) {
+  } catch (_err) {
     throw new Error("Invalid regulation snapshot JSON");
   }
   if (!Array.isArray(parsed)) {
@@ -258,6 +294,7 @@ export function importRegSnapshots(raw: string): RegulationSnapshot[] {
       const { id, createdAt, description } = item;
       if (!id || !description) return null;
       const aggregated = item.aggregatedRolling || {};
+      const sanitizedObjective = sanitizeObjective(item.objective);
       return {
         ...item,
         version: typeof item.version === "number" ? item.version : REG_SNAPSHOT_VERSION,
@@ -270,6 +307,7 @@ export function importRegSnapshots(raw: string): RegulationSnapshot[] {
           tv_ids_order: Array.isArray(aggregated.tv_ids_order) ? [...aggregated.tv_ids_order] : undefined,
           timeLabels: Array.isArray(aggregated.timeLabels) ? [...aggregated.timeLabels] : undefined,
         },
+        objective: sanitizedObjective,
       } as RegulationSnapshot;
     })
     .filter(Boolean) as RegulationSnapshot[];


### PR DESCRIPTION
## Summary
- surface the regulation objective score and component breakdown in the results dialog
- persist objective metrics inside regulation snapshots so comparison data can include them
- add an objective comparison section to the regulation comparison page alongside delay statistics

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8171be76c832bbfb7b8278e3145b1