### PR TITLE
Add regulation proposal preview panel and API integration

### DIFF
--- a/src/app/flows/page.tsx
+++ b/src/app/flows/page.tsx
@@ -6,6 +6,7 @@ import { useSimStore } from '@/components/useSimStore';
 import FlowCanvas from "@/components/FlowCanvas";
 import LeftControl1Flow from "@/components/LeftControl1Flow";
 import FlowRegulationPanel from "@/components/FlowRegulationPanel";
+import RegulationProposalPanel from "@/components/RegulationProposalPanel";
 import FlowAirspaceView from "@/components/FlowAirspaceView";
 import FlowPlanPanel from "@/components/FlowPlanPanel";
 import Header from "@/components/Header";
@@ -77,6 +78,9 @@ export default function FlowsPage() {
         <div className="w-[384px] h-full min-h-0 overflow-y-auto no-scrollbar flex flex-col gap-4 pt-16 pb-4 pointer-events-none">
           <div className="pointer-events-auto">
             <FlowRegulationPanel embedded />
+          </div>
+          <div className="pointer-events-auto">
+            <RegulationProposalPanel embedded />
           </div>
           <div className="pointer-events-auto">
             <FlowAirspaceView embedded />

--- a/src/components/FlowCanvas.tsx
+++ b/src/components/FlowCanvas.tsx
@@ -16,7 +16,7 @@ export default function FlowCanvas() {
   const rafRef = useRef<number | undefined>(undefined);
   const lastTs = useRef<number>(performance.now());
   const lastUpdateRef = useRef<number>(performance.now());
-  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showTrafficVolumes, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, flowViewEnabled, flowCommunities, flowGroups, flowPreviewGroupId, flowPreviewFlightId, regulationTargetFlightIds, regulationPreviewActive, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
+  const { t, date, weatherOverlay, tick, setRange, showFlightLineLabels, showTrafficVolumes, setFlights, setSelectedTrafficVolume, flLowerBound, flUpperBound, showHotspots, hotspots, getActiveHotspots, flowViewEnabled, flowCommunities, flowGroups, flowPreviewGroupId, flowPreviewFlightId, regulationTargetFlightIds, regulationPreviewActive, proposalPreviewActive, proposalPreviewFlightIds, playing, focusMode, focusFlightIds, showFlightLines, selectedTrafficVolume } = useSimStore();
 
   const [highlightedTrafficVolume, setHighlightedTrafficVolume] = useState<string | null>(null);
   const [hoveredTrafficVolume, setHoveredTrafficVolume] = useState<string | null>(null);
@@ -275,6 +275,11 @@ export default function FlowCanvas() {
   // Ensure filters also react to flow mapping toggles (e.g., Flow Basket eye button)
   useEffect(() => { updateFlightLineFilters(mapRef.current); }, [flowViewEnabled, flowCommunities, flowGroups]);
 
+  useEffect(() => {
+    updateFlightLineFilters(mapRef.current);
+    updateFlowRendering(mapRef.current);
+  }, [proposalPreviewActive, proposalPreviewFlightIds]);
+
   // Weather overlay integration (Surface Precipitation)
   useEffect(() => {
     const map = mapRef.current;
@@ -459,7 +464,9 @@ function updateFlightLineFilters(map: maplibregl.Map | null) {
   // When Flow View is enabled and communities are present, restrict to those flights
   let lineIdsToShow: string[];
   // Flight-level preview takes precedence over any group preview or other filters
-  if (sim.regulationPreviewActive) {
+  if (sim.proposalPreviewActive) {
+    lineIdsToShow = Array.from(sim.proposalPreviewFlightIds || []).map(String);
+  } else if (sim.regulationPreviewActive) {
     lineIdsToShow = Array.from(sim.regulationTargetFlightIds).map(String);
   } else if (sim.flowPreviewFlightId) {
     // Flow preview hovers are next-highest priority
@@ -535,7 +542,13 @@ function updateFlowRendering(map: maplibregl.Map | null) {
   const sim = useSimStore.getState();
   if (!map.getLayer('flight-lines')) return;
 
-  if (!sim.regulationPreviewActive && sim.flowViewEnabled && sim.flowCommunities && Object.keys(sim.flowCommunities).length > 0) {
+  if (
+    !sim.proposalPreviewActive &&
+    !sim.regulationPreviewActive &&
+    sim.flowViewEnabled &&
+    sim.flowCommunities &&
+    Object.keys(sim.flowCommunities).length > 0
+  ) {
     // Only apply flow coloring when regulation preview is off
     const colorByCommunity = new Map<string, string>(
       Object.entries(sim.flowColorByCommunity || {})
@@ -587,7 +600,7 @@ function updateFlowRendering(map: maplibregl.Map | null) {
   const sectorOutlineId = 'sector-outline';
   const sectorLabelsId = 'sector-labels';
 
-  if (sim.flowViewEnabled && !sim.regulationPreviewActive) {
+  if (sim.flowViewEnabled && !sim.regulationPreviewActive && !sim.proposalPreviewActive) {
     // Keep base sector visuals hidden only when flow view has priority
     if (map.getLayer(sectorFillId)) {
       map.setPaintProperty(sectorFillId, 'fill-opacity', 0);

--- a/src/components/FlowRegulationPanel.tsx
+++ b/src/components/FlowRegulationPanel.tsx
@@ -7,6 +7,7 @@ import { useSimStore } from "@/components/useSimStore";
 import ShimmeringText from "@/components/ShimmeringText";
 import HourGlass from "@/components/HourGlass";
 import FlightStatisticsButton from "@/components/FlightStatisticsButton";
+import { toTimeWindow } from "@/lib/regulationProposals";
 
 type FlowRegulationPanelProps = { embedded?: boolean };
 
@@ -20,7 +21,10 @@ export default function FlowRegulationPanel({ embedded = false }: FlowRegulation
     setFlowError,
     flowColorByCommunity,
     setFlowPreviewGroupId,
-    setFlowPreviewFlightId
+    setFlowPreviewFlightId,
+    fetchRegulationProposals,
+    proposalLoading,
+    resetProposalState,
   } = useSimStore();
   const [open, setOpen] = useState(true);
   const [loading, setLoading] = useState(false);
@@ -31,6 +35,7 @@ export default function FlowRegulationPanel({ embedded = false }: FlowRegulation
   const [toTime, setToTime] = useState<string>(secToHHMM(t + 2 * 3600));
   const [extracting, setExtracting] = useState(false);
   const [extractError, setExtractError] = useState<string | null>(null);
+  const [proposalTriggerError, setProposalTriggerError] = useState<string | null>(null);
   const [flowResults, setFlowResults] = useState<FlowsResponse | null>(null);
   const [openAddMenuFor, setOpenAddMenuFor] = useState<string | null>(null);
   // Flow extraction params
@@ -179,8 +184,19 @@ export default function FlowRegulationPanel({ embedded = false }: FlowRegulation
       setFlowError(null);
       setFlowPreviewGroupId(null);
       setFlowPreviewFlightId(null);
+      resetProposalState();
     }
-  }, [selectedTVs, setFlowCommunities, setFlowViewEnabled, setFlowError]);
+  }, [selectedTVs, setFlowCommunities, setFlowViewEnabled, setFlowError, resetProposalState]);
+
+  useEffect(() => {
+    setProposalTriggerError(null);
+  }, [selectedTVs, fromTime, toTime]);
+
+  useEffect(() => {
+    if (!open) {
+      resetProposalState();
+    }
+  }, [open, resetProposalState]);
 
   // Clear preview when results are not shown anymore; ensure cleanup on unmount
   useEffect(() => {
@@ -201,6 +217,34 @@ export default function FlowRegulationPanel({ embedded = false }: FlowRegulation
         <div>
           <div className="text-[10px] uppercase tracking-wider opacity-70">Traffic Flows</div>
           <div className="text-lg font-semibold">Select and Extract</div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            aria-label="Propose regulation bundles"
+            type="button"
+            onClick={async () => {
+              if (selectedTVs.length !== 1) {
+                setProposalTriggerError('Select exactly one traffic volume to propose regulations.');
+                return;
+              }
+              if (!valid) {
+                setProposalTriggerError('Invalid time window; end must be after start.');
+                return;
+              }
+              setProposalTriggerError(null);
+              const query = {
+                trafficVolumeId: selectedTVs[0],
+                timeWindow: toTimeWindow(fromTime, toTime),
+              };
+              await fetchRegulationProposals(query);
+            }}
+            disabled={proposalLoading}
+            className={`px-3 py-1 rounded-lg border text-xs transition-colors ${proposalLoading
+              ? 'border-blue-400/50 bg-blue-500/20 text-blue-100'
+              : 'border-white/30 bg-white/10 text-white/80 hover:bg-white/15'}`}
+          >
+            {proposalLoading ? 'Loading…' : 'Propose'}
+          </button>
         </div>
       </div>
 
@@ -257,6 +301,9 @@ export default function FlowRegulationPanel({ embedded = false }: FlowRegulation
           </div>
           {!valid && (
             <div className="text-[11px] text-red-200 mt-1">End time must be after start time</div>
+          )}
+          {proposalTriggerError && (
+            <div className="text-[11px] text-red-200 mt-1">{proposalTriggerError}</div>
           )}
         </div>
 

--- a/src/components/RegulationProposalPanel.tsx
+++ b/src/components/RegulationProposalPanel.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSimStore } from "@/components/useSimStore";
+import {
+  RegulationProposal,
+  collectProposalFlights,
+  ProposalFlow,
+} from "@/lib/regulationProposals";
+
+function formatNumber(value: number | null | undefined, digits = 2): string {
+  if (value === null || value === undefined || Number.isNaN(value)) return "–";
+  return value.toFixed(digits);
+}
+
+type RegulationProposalPanelProps = {
+  embedded?: boolean;
+};
+
+type FeatureSummary = {
+  vAvg: number | null;
+  slack15Avg: number | null;
+  slack30Avg: number | null;
+  totalFlights: number;
+};
+
+function summarizeProposalFeatures(proposal: RegulationProposal): FeatureSummary {
+  const accumulator = {
+    vSum: 0,
+    vCount: 0,
+    s15Sum: 0,
+    s15Count: 0,
+    s30Sum: 0,
+    s30Count: 0,
+    flights: 0,
+  };
+  for (const flow of proposal.flows || []) {
+    const features = flow.features || {};
+    if (typeof features.v_tilde === "number") {
+      accumulator.vSum += features.v_tilde;
+      accumulator.vCount += 1;
+    }
+    if (typeof features.slack15 === "number") {
+      accumulator.s15Sum += features.slack15;
+      accumulator.s15Count += 1;
+    }
+    if (typeof features.slack30 === "number") {
+      accumulator.s30Sum += features.slack30;
+      accumulator.s30Count += 1;
+    }
+    if (typeof features.num_flights === "number") {
+      accumulator.flights += features.num_flights;
+    } else {
+      accumulator.flights += flow.flight_ids?.length || 0;
+    }
+  }
+  return {
+    vAvg: accumulator.vCount > 0 ? accumulator.vSum / accumulator.vCount : null,
+    slack15Avg: accumulator.s15Count > 0 ? accumulator.s15Sum / accumulator.s15Count : null,
+    slack30Avg: accumulator.s30Count > 0 ? accumulator.s30Sum / accumulator.s30Count : null,
+    totalFlights: accumulator.flights,
+  };
+}
+
+function summarizeFlowFeatures(flow: ProposalFlow) {
+  const features = flow.features || {};
+  return {
+    v: typeof features.v_tilde === "number" ? features.v_tilde : null,
+    slack15: typeof features.slack15 === "number" ? features.slack15 : null,
+    slack30: typeof features.slack30 === "number" ? features.slack30 : null,
+    flights: typeof features.num_flights === "number" ? features.num_flights : flow.flight_ids?.length || 0,
+  };
+}
+
+export default function RegulationProposalPanel({ embedded = false }: RegulationProposalPanelProps) {
+  const {
+    isRegulationProposalPanelOpen,
+    proposalLoading,
+    proposalError,
+    proposalResults,
+    proposalQuery,
+    proposalPreviewAll,
+    proposalPinnedProposals,
+    proposalPinnedFlows,
+    togglePreviewAllProposals,
+    toggleProposalEye,
+    toggleProposalFlowEye,
+    setProposalPreview,
+    clearProposalPreview,
+    fetchRegulationProposals,
+    resetProposalState,
+  } = useSimStore();
+
+  const [topKInput, setTopKInput] = useState<string>("");
+  const [topKError, setTopKError] = useState<string | null>(null);
+  const [expandedProposals, setExpandedProposals] = useState<Record<string, boolean>>({});
+  const [expandedFlightLists, setExpandedFlightLists] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    const nextTopK = proposalQuery?.topK ?? proposalResults?.top_k;
+    setTopKInput(nextTopK != null ? String(nextTopK) : "");
+    setTopKError(null);
+    setExpandedProposals({});
+    setExpandedFlightLists({});
+  }, [proposalQuery, proposalResults]);
+
+  const showPanel = isRegulationProposalPanelOpen || proposalLoading;
+
+  const uniqueFlowCount = useMemo(() => {
+    const ids = new Set<string>();
+    for (const proposal of proposalResults?.proposals || []) {
+      for (const flow of proposal.flows || []) {
+        ids.add(String(flow.flow_id));
+      }
+    }
+    return ids.size;
+  }, [proposalResults]);
+
+  if (!showPanel) {
+    return null;
+  }
+
+  const containerClass = embedded
+    ? "w-full rounded-2xl border border-white/20 bg-white/20 backdrop-blur-md shadow-xl text-white flex flex-col"
+    : "absolute top-20 right-4 z-40 w-[420px] max-h-[calc(100vh-6rem)] rounded-2xl border border-white/20 bg-white/20 backdrop-blur-md shadow-xl text-white flex flex-col";
+
+  const proposals = proposalResults?.proposals || [];
+
+  const handleRerun = async () => {
+    if (!proposalQuery) return;
+    let topK: number | undefined;
+    if (topKInput.trim().length > 0) {
+      const parsed = Number(topKInput);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        setTopKError("Top K must be a positive number");
+        return;
+      }
+      topK = Math.round(parsed);
+    }
+    setTopKError(null);
+    await fetchRegulationProposals({
+      trafficVolumeId: proposalQuery.trafficVolumeId,
+      timeWindow: proposalQuery.timeWindow,
+      topK,
+    });
+  };
+
+  const handleProposalHover = (proposal: RegulationProposal | null) => {
+    if (!proposal) return;
+    const ids = collectProposalFlights(proposal);
+    setProposalPreview(ids, proposal.id);
+  };
+
+  const handleFlowHover = (proposal: RegulationProposal, flow: ProposalFlow) => {
+    const ids = new Set((flow.flight_ids || []).map((id) => String(id)));
+    setProposalPreview(ids, `${proposal.id}::${flow.flow_id}`);
+  };
+
+  const handleClearPreview = () => {
+    clearProposalPreview();
+  };
+
+  const renderFlightList = (proposalId: string, flow: ProposalFlow) => {
+    const key = `${proposalId}::${flow.flow_id}`;
+    const expanded = expandedFlightLists[key] ?? false;
+    const flights = flow.flight_ids || [];
+    const slice = expanded ? flights : flights.slice(0, 30);
+    if (flights.length === 0) {
+      return <div className="text-xs text-white/60">No flights listed</div>;
+    }
+    return (
+      <div className="mt-2 space-y-2">
+        <table className="w-full text-[11px] text-white/80">
+          <tbody>
+            {slice.map((flightId) => (
+              <tr key={flightId} className="border-b border-white/10 last:border-0">
+                <td className="py-1 font-mono">{flightId}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {flights.length > 30 && (
+          <button
+            onClick={() =>
+              setExpandedFlightLists((prev) => ({ ...prev, [key]: !expanded }))
+            }
+            type="button"
+            className="text-xs text-blue-200 hover:text-blue-100 underline"
+          >
+            {expanded ? "Show less" : `See more (${flights.length - 30} more)`}
+          </button>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className={containerClass}>
+      <div className="flex items-center justify-between p-4 border-b border-white/20">
+        <div>
+          <div className="text-lg font-semibold">Regulation Proposals</div>
+          <div className="text-xs opacity-70">({uniqueFlowCount} flows)</div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            aria-label="Preview all proposal flights"
+            aria-pressed={proposalPreviewAll}
+            type="button"
+            onClick={togglePreviewAllProposals}
+            className={`px-2 py-1 rounded-lg border text-xs ${proposalPreviewAll
+              ? 'border-blue-400 bg-blue-500/20 text-blue-100'
+              : 'border-white/30 bg-white/10 text-white/80 hover:bg-white/15'}`}
+          >
+            👁 Preview All
+          </button>
+          <button
+            aria-label="Re-run regulation proposals"
+            disabled={!proposalQuery || proposalLoading || !!topKError}
+            type="button"
+            onClick={handleRerun}
+            className={`px-2 py-1 rounded-lg border text-xs ${proposalLoading
+              ? 'border-blue-400/50 bg-blue-500/20 text-blue-100'
+              : 'border-white/30 bg-white/10 text-white/80 hover:bg-white/15'}`}
+          >
+            {proposalLoading ? 'Loading…' : 'Re-run'}
+          </button>
+          <button
+            aria-label="Close regulation proposal panel"
+            type="button"
+            onClick={resetProposalState}
+            className="px-2 py-1 rounded-lg border border-white/30 bg-white/10 text-xs text-white/80 hover:bg-white/15"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto no-scrollbar p-4 space-y-4">
+        {proposalError && (
+          <div className="rounded-lg border border-red-300/40 bg-red-400/10 px-3 py-2 text-xs text-red-100">
+            {proposalError}
+          </div>
+        )}
+
+        {proposalResults && (
+          <div className="flex flex-wrap gap-2 text-xs">
+            <span className="rounded-full bg-white/10 px-3 py-1">TV: {proposalResults.traffic_volume_id}</span>
+            <span className="rounded-full bg-white/10 px-3 py-1">Window: {proposalResults.time_window}</span>
+            <span className="rounded-full bg-white/10 px-3 py-1">Bin: {proposalResults.time_bin_minutes} min</span>
+            <span className="rounded-full bg-white/10 px-3 py-1">Top K: {proposalResults.top_k}</span>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 text-xs">
+          <label className="flex items-center gap-2">
+            <span className="opacity-70">Top K override</span>
+            <input
+              type="number"
+              min={1}
+              className="w-20 rounded-md border border-white/20 bg-white/10 px-2 py-1 text-right text-white focus:outline-none"
+              value={topKInput}
+              onChange={(e) => {
+                setTopKInput(e.target.value);
+              }}
+              placeholder={proposalResults?.top_k ? String(proposalResults.top_k) : ""}
+            />
+          </label>
+          {topKError && <span className="text-[11px] text-red-200">{topKError}</span>}
+        </div>
+
+        {proposalLoading && (
+          <div className="space-y-3">
+            {[...Array(3)].map((_, idx) => (
+              <div key={idx} className="h-16 animate-pulse rounded-lg bg-white/10" />
+            ))}
+          </div>
+        )}
+
+        {!proposalLoading && proposals.length === 0 && (
+          <div className="rounded-lg border border-white/10 bg-white/5 p-4 text-sm text-white/70">
+            No regulation proposals returned for this request.
+          </div>
+        )}
+
+        {!proposalLoading && proposals.map((proposal) => {
+          const expanded = expandedProposals[proposal.id] ?? false;
+          const summary = summarizeProposalFeatures(proposal);
+          const improvement = proposal.objective_improvement || { delta_deficit_per_hour: 0, delta_objective_score: 0 };
+          const isPinned = proposalPreviewAll || proposalPinnedProposals.has(proposal.id);
+          return (
+            <div
+              key={proposal.id}
+              className="rounded-xl border border-white/15 bg-white/10"
+              onMouseLeave={handleClearPreview}
+            >
+              <div
+                className={`flex cursor-pointer flex-col gap-2 p-4 transition-colors hover:bg-white/10 ${isPinned ? 'border-l-4 border-l-blue-400' : ''}`}
+                onMouseEnter={() => handleProposalHover(proposal)}
+                onClick={() =>
+                  setExpandedProposals((prev) => ({ ...prev, [proposal.id]: !expanded }))
+                }
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div>
+                    <div className="text-sm font-semibold">{proposal.id}</div>
+                    <div className="text-[11px] opacity-70">{proposal.control_window?.label} · ({proposal.flows?.length || 0} flows)</div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="flex flex-col text-right text-[11px]">
+                      <span>Δ deficit/hr: {formatNumber(improvement.delta_deficit_per_hour)}</span>
+                      <span>Δ objective: {formatNumber(improvement.delta_objective_score)}</span>
+                    </div>
+                    <button
+                      aria-label={`Toggle preview for ${proposal.id}`}
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleProposalEye(proposal.id);
+                      }}
+                      className={`rounded-lg border px-2 py-1 text-xs ${isPinned
+                        ? 'border-blue-400 bg-blue-500/20 text-blue-100'
+                        : 'border-white/30 bg-white/10 text-white/80 hover:bg-white/15'}`}
+                    >
+                      👁
+                    </button>
+                    <button
+                      aria-label={`Expand details for ${proposal.id}`}
+                      type="button"
+                      className="rounded-lg border border-white/30 bg-white/10 px-2 py-1 text-xs text-white/70"
+                    >
+                      {expanded ? 'Hide' : 'View'}
+                    </button>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2 text-[11px] opacity-80">
+                  <span className="rounded-full bg-white/5 px-2 py-1">V {formatNumber(summary.vAvg)}</span>
+                  <span className="rounded-full bg-white/5 px-2 py-1">S15 {formatNumber(summary.slack15Avg)}</span>
+                  <span className="rounded-full bg-white/5 px-2 py-1">S30 {formatNumber(summary.slack30Avg)}</span>
+                  <span className="rounded-full bg-white/5 px-2 py-1">N {summary.totalFlights}</span>
+                </div>
+              </div>
+              {expanded && (
+                <div className="space-y-4 border-t border-white/10 p-4 text-xs">
+                  <div className="grid gap-1">
+                    <div className="font-semibold text-white/80">Objective Components</div>
+                    <table className="w-full text-left text-[11px]">
+                      <thead>
+                        <tr className="text-white/60">
+                          <th className="py-1">Component</th>
+                          <th className="py-1">Before</th>
+                          <th className="py-1">After</th>
+                          <th className="py-1">Δ</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Array.from(new Set([
+                          ...Object.keys(proposal.objective_components?.before || {}),
+                          ...Object.keys(proposal.objective_components?.after || {}),
+                          ...Object.keys(proposal.objective_components?.delta || {}),
+                        ])).map((key) => (
+                          <tr key={key} className="border-t border-white/10">
+                            <td className="py-1 font-medium">{key}</td>
+                            <td className="py-1">{formatNumber(proposal.objective_components?.before?.[key])}</td>
+                            <td className="py-1">{formatNumber(proposal.objective_components?.after?.[key])}</td>
+                            <td className="py-1">{formatNumber(proposal.objective_components?.delta?.[key])}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+
+                  <div>
+                    <div className="mb-2 font-semibold text-white/80">Flows</div>
+                    <div className="space-y-3">
+                      {proposal.flows?.map((flow) => {
+                        const key = `${proposal.id}::${flow.flow_id}`;
+                        const flowFeatures = summarizeFlowFeatures(flow);
+                        const flowPinned = proposalPreviewAll || proposalPinnedFlows.has(key);
+                        return (
+                          <div
+                            key={key}
+                            className={`rounded-lg border border-white/15 bg-white/5 p-3 transition-colors hover:bg-white/10 ${flowPinned ? 'border-blue-400/70' : ''}`}
+                            onMouseEnter={() => handleFlowHover(proposal, flow)}
+                            onMouseLeave={handleClearPreview}
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2 text-[11px]">
+                              <div className="font-semibold">Flow {flow.flow_id}</div>
+                              <div className="text-white/70">{flow.control_volume_id || '—'}</div>
+                              <div>
+                                {formatNumber(flow.baseline_rate_per_hour, 1)} → {formatNumber(flow.allowed_rate_per_hour, 1)}
+                              </div>
+                              <div>Cut/hr {formatNumber(flow.assigned_cut_per_hour, 1)}</div>
+                              <div>V {formatNumber(flowFeatures.v)}</div>
+                              <div>S15 {formatNumber(flowFeatures.slack15)}</div>
+                              <div>S30 {formatNumber(flowFeatures.slack30)}</div>
+                              <div>N {flowFeatures.flights}</div>
+                              <button
+                                aria-label={`Toggle preview for flow ${flow.flow_id}`}
+                                type="button"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  toggleProposalFlowEye(proposal.id, flow.flow_id);
+                                }}
+                                className={`rounded-lg border px-2 py-1 text-xs ${flowPinned
+                                  ? 'border-blue-400 bg-blue-500/20 text-blue-100'
+                                  : 'border-white/30 bg-white/10 text-white/80 hover:bg-white/15'}`}
+                              >
+                                👁
+                              </button>
+                              <button
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  setExpandedFlightLists((prev) => ({ ...prev, [key]: ! (prev[key] ?? false) }));
+                                }}
+                                type="button"
+                                className="rounded-lg border border-white/30 bg-white/10 px-2 py-1 text-xs text-white/70"
+                              >
+                                {expandedFlightLists[key] ? 'Hide Flights' : 'Flight List'}
+                              </button>
+                            </div>
+                            {expandedFlightLists[key] && renderFlightList(proposal.id, flow)}
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+
+                  {(proposal.diagnostics || Object.keys(proposalResults?.weights || {}).length > 0) && (
+                    <details className="rounded-lg border border-white/10 bg-white/5 p-3">
+                      <summary className="cursor-pointer text-white/80">Weights & Diagnostics</summary>
+                      <div className="mt-2 space-y-3 text-[11px] text-white/70">
+                        {proposalResults?.weights && (
+                          <div>
+                            <div className="font-semibold text-white/80">Weights</div>
+                            <div className="mt-1 grid grid-cols-2 gap-1">
+                              {Object.entries(proposalResults.weights).map(([k, v]) => (
+                                <div key={k} className="flex justify-between">
+                                  <span>{k}</span>
+                                  <span>{formatNumber(v)}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {proposal.diagnostics && (
+                          <div>
+                            <div className="font-semibold text-white/80">Diagnostics</div>
+                            <div className="mt-1 grid grid-cols-2 gap-1">
+                              {Object.entries(proposal.diagnostics).map(([k, v]) => (
+                                <div key={k} className="flex justify-between">
+                                  <span>{k}</span>
+                                  <span>{formatNumber(v)}</span>
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    </details>
+                  )}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/useSimStore.ts
+++ b/src/components/useSimStore.ts
@@ -2,6 +2,13 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { Trajectory, SectorFeatureProps, RegulationPlanSimulationResponse } from "@/lib/models";
+import {
+  collectAllProposalFlights,
+  collectProposalFlights,
+  ProposeRegulationsRequest,
+  ProposeRegulationsResponse,
+  proposeRegulations,
+} from "@/lib/regulationProposals";
 
 interface User {
   email: string;
@@ -63,6 +70,12 @@ interface Regulation {
   createdAt: number;
 }
 
+export type ProposalQuery = {
+  trafficVolumeId: string;
+  timeWindow: string;
+  topK?: number;
+};
+
 type State = {
   t: number;               // current sim time (s)
   range: [number, number]; // global window
@@ -107,6 +120,20 @@ type State = {
   regulationRate: number;
   regulations: Regulation[];
   isRegulationPanelOpen: boolean;
+  // Regulation proposals
+  isRegulationProposalPanelOpen: boolean;
+  proposalLoading: boolean;
+  proposalError: string | null;
+  proposalQuery: ProposalQuery | null;
+  proposalResults: ProposeRegulationsResponse | null;
+  proposalPreviewActive: boolean;
+  proposalPreviewFlightIds: Set<string>;
+  proposalPreviewProposalId: string | null;
+  proposalPreviewAll: boolean;
+  proposalHoverFlightIds: Set<string>;
+  proposalPinnedProposals: Set<string>;
+  proposalPinnedFlows: Set<string>;
+  proposalPinnedFlightIds: Set<string>;
   // Simulation results modal
   regulationSimulationResult: RegulationPlanSimulationResponse | null;
   isResultsOpen: boolean;
@@ -168,6 +195,14 @@ type State = {
   addRegulation: (regulation: Omit<Regulation, 'id' | 'createdAt'>) => void;
   removeRegulation: (id: string) => void;
   setIsRegulationPanelOpen: (open: boolean) => void;
+  setIsRegulationProposalPanelOpen: (open: boolean) => void;
+  fetchRegulationProposals: (q: ProposalQuery) => Promise<void>;
+  setProposalPreview: (ids: Set<string>, proposalId?: string | null) => void;
+  clearProposalPreview: () => void;
+  toggleProposalEye: (proposalId: string) => void;
+  toggleProposalFlowEye: (proposalId: string, flowId: string | number) => void;
+  togglePreviewAllProposals: () => void;
+  resetProposalState: () => void;
   setRegulationEditPayload: (p: Omit<Regulation, 'id' | 'createdAt'> | null) => void;
   setRegulationSimulationResult: (r: RegulationPlanSimulationResponse | null) => void;
   setIsResultsOpen: (open: boolean) => void;
@@ -256,6 +291,19 @@ const defaultState: Pick<State,
   | 'regulationRate'
   | 'regulations'
   | 'isRegulationPanelOpen'
+  | 'isRegulationProposalPanelOpen'
+  | 'proposalLoading'
+  | 'proposalError'
+  | 'proposalQuery'
+  | 'proposalResults'
+  | 'proposalPreviewActive'
+  | 'proposalPreviewFlightIds'
+  | 'proposalPreviewProposalId'
+  | 'proposalPreviewAll'
+  | 'proposalHoverFlightIds'
+  | 'proposalPinnedProposals'
+  | 'proposalPinnedFlows'
+  | 'proposalPinnedFlightIds'
   | 'regulationEditPayload'
   | 'regulationSimulationResult'
   | 'isResultsOpen'
@@ -307,6 +355,19 @@ const defaultState: Pick<State,
   regulationRate: 0,
   regulations: [],
   isRegulationPanelOpen: false,
+  isRegulationProposalPanelOpen: false,
+  proposalLoading: false,
+  proposalError: null,
+  proposalQuery: null,
+  proposalResults: null,
+  proposalPreviewActive: false,
+  proposalPreviewFlightIds: new Set<string>(),
+  proposalPreviewProposalId: null,
+  proposalPreviewAll: false,
+  proposalHoverFlightIds: new Set<string>(),
+  proposalPinnedProposals: new Set<string>(),
+  proposalPinnedFlows: new Set<string>(),
+  proposalPinnedFlightIds: new Set<string>(),
   regulationEditPayload: null,
   regulationSimulationResult: null,
   isResultsOpen: false,
@@ -320,9 +381,58 @@ const defaultState: Pick<State,
   user: null,
 };
 
-export const useSimStore = create(persist<State, [], [], Pick<State, 'user'>>((set, get) => ({
-  ...defaultState,
-  setUser: (user) => set({ user }),
+export const useSimStore = create(persist<State, [], [], Pick<State, 'user'>>((set, get) => {
+  const recomputePinnedFlights = (
+    nextPinnedProposals: Set<string>,
+    nextPinnedFlows: Set<string>
+  ) => {
+    const flights = new Set<string>();
+    const results = get().proposalResults;
+    if (!results) return flights;
+    for (const proposal of results.proposals || []) {
+      if (nextPinnedProposals.has(proposal.id)) {
+        collectProposalFlights(proposal).forEach((id) => flights.add(String(id)));
+      }
+      for (const flow of proposal.flows || []) {
+        const key = `${proposal.id}::${flow.flow_id}`;
+        if (nextPinnedFlows.has(key)) {
+          for (const fid of flow.flight_ids || []) {
+            flights.add(String(fid));
+          }
+        }
+      }
+    }
+    return flights;
+  };
+
+  const applyProposalPreview = (opts?: {
+    hover?: Set<string>;
+    proposalId?: string | null;
+    previewAll?: boolean;
+  }) => {
+    const state = get();
+    const previewAll = opts?.previewAll ?? state.proposalPreviewAll;
+    const base = previewAll
+      ? collectAllProposalFlights(state.proposalResults)
+      : new Set(state.proposalPinnedFlightIds);
+    const hoverSet = opts?.hover
+      ? new Set(Array.from(opts.hover).map(String))
+      : new Set(state.proposalHoverFlightIds);
+    const combined = new Set<string>();
+    base.forEach((id) => combined.add(String(id)));
+    hoverSet.forEach((id) => combined.add(String(id)));
+    set({
+      proposalPreviewAll: previewAll,
+      proposalPreviewActive: combined.size > 0,
+      proposalPreviewFlightIds: combined,
+      proposalPreviewProposalId: opts?.proposalId ?? null,
+      proposalHoverFlightIds: hoverSet,
+    });
+  };
+
+  return {
+    ...defaultState,
+    setUser: (user) => set({ user }),
   login: async (email: string, password: string) => {
     try {
       const res = await fetch('/api/token', {
@@ -457,6 +567,115 @@ export const useSimStore = create(persist<State, [], [], Pick<State, 'user'>>((s
     set(state => ({ regulations: state.regulations.filter(r => r.id !== id) }));
   },
   setIsRegulationPanelOpen: (open) => set({ isRegulationPanelOpen: open }),
+  setIsRegulationProposalPanelOpen: (open) => set({ isRegulationProposalPanelOpen: open }),
+  fetchRegulationProposals: async (q) => {
+    set({
+      isRegulationProposalPanelOpen: true,
+      proposalLoading: true,
+      proposalError: null,
+      proposalQuery: q,
+      proposalResults: null,
+      proposalPreviewActive: false,
+      proposalPreviewFlightIds: new Set<string>(),
+      proposalPreviewProposalId: null,
+      proposalPreviewAll: false,
+      proposalHoverFlightIds: new Set<string>(),
+      proposalPinnedProposals: new Set<string>(),
+      proposalPinnedFlows: new Set<string>(),
+      proposalPinnedFlightIds: new Set<string>(),
+    });
+    try {
+      const body: ProposeRegulationsRequest = {
+        traffic_volume_id: q.trafficVolumeId,
+        time_window: q.timeWindow,
+      };
+      if (q.topK != null) {
+        body.top_k_regulations = q.topK;
+      }
+      const data = await proposeRegulations(body);
+      set({
+        proposalResults: data,
+        proposalLoading: false,
+        proposalError: null,
+      });
+      applyProposalPreview({ hover: new Set<string>(), proposalId: null, previewAll: false });
+    } catch (error: any) {
+      set({
+        proposalLoading: false,
+        proposalError: error?.message || 'Failed to fetch regulation proposals',
+      });
+      applyProposalPreview({ hover: new Set<string>(), proposalId: null, previewAll: false });
+    }
+  },
+  setProposalPreview: (ids, proposalId = null) => {
+    applyProposalPreview({ hover: ids, proposalId: proposalId ?? null });
+  },
+  clearProposalPreview: () => {
+    applyProposalPreview({ hover: new Set<string>(), proposalId: null });
+  },
+  toggleProposalEye: (proposalId) => {
+    const state = get();
+    if (!state.proposalResults) return;
+    const nextPinnedProposals = new Set(state.proposalPinnedProposals);
+    if (nextPinnedProposals.has(proposalId)) {
+      nextPinnedProposals.delete(proposalId);
+    } else {
+      nextPinnedProposals.add(proposalId);
+    }
+    const nextPinnedFlows = new Set(state.proposalPinnedFlows);
+    const nextPinnedFlights = recomputePinnedFlights(nextPinnedProposals, nextPinnedFlows);
+    set({
+      proposalPinnedProposals: nextPinnedProposals,
+      proposalPinnedFlows: nextPinnedFlows,
+      proposalPinnedFlightIds: nextPinnedFlights,
+    });
+    applyProposalPreview();
+  },
+  toggleProposalFlowEye: (proposalId, flowId) => {
+    const state = get();
+    if (!state.proposalResults) return;
+    const key = `${proposalId}::${flowId}`;
+    const nextPinnedFlows = new Set(state.proposalPinnedFlows);
+    if (nextPinnedFlows.has(key)) {
+      nextPinnedFlows.delete(key);
+    } else {
+      nextPinnedFlows.add(key);
+    }
+    const nextPinnedProposals = new Set(state.proposalPinnedProposals);
+    const nextPinnedFlights = recomputePinnedFlights(nextPinnedProposals, nextPinnedFlows);
+    set({
+      proposalPinnedProposals: nextPinnedProposals,
+      proposalPinnedFlows: nextPinnedFlows,
+      proposalPinnedFlightIds: nextPinnedFlights,
+    });
+    applyProposalPreview();
+  },
+  togglePreviewAllProposals: () => {
+    const state = get();
+    const nextAll = !state.proposalPreviewAll;
+    applyProposalPreview({
+      hover: state.proposalHoverFlightIds,
+      proposalId: null,
+      previewAll: nextAll,
+    });
+  },
+  resetProposalState: () => {
+    set({
+      isRegulationProposalPanelOpen: false,
+      proposalLoading: false,
+      proposalError: null,
+      proposalQuery: null,
+      proposalResults: null,
+      proposalPreviewActive: false,
+      proposalPreviewFlightIds: new Set<string>(),
+      proposalPreviewProposalId: null,
+      proposalPreviewAll: false,
+      proposalHoverFlightIds: new Set<string>(),
+      proposalPinnedProposals: new Set<string>(),
+      proposalPinnedFlows: new Set<string>(),
+      proposalPinnedFlightIds: new Set<string>(),
+    });
+  },
   setRegulationEditPayload: (p) => set({ regulationEditPayload: p }),
   setRegulationSimulationResult: (r) => set({ regulationSimulationResult: r }),
   setIsResultsOpen: (open) => set({ isResultsOpen: open }),
@@ -573,7 +792,8 @@ export const useSimStore = create(persist<State, [], [], Pick<State, 'user'>>((s
       })
     }));
   }
-}),
+  };
+},
 {
   name: 'sim-storage',
   partialize: (state) => ({ user: state.user }),

--- a/src/lib/regulationProposals.ts
+++ b/src/lib/regulationProposals.ts
@@ -1,0 +1,123 @@
+import { authFetch } from "@/lib/auth";
+
+export type ProposeRegulationsRequest = {
+  traffic_volume_id: string;
+  time_window: string;
+  top_k_regulations?: number;
+};
+
+export type ProposalFlowFeatures = {
+  gH?: number;
+  v_tilde?: number;
+  rho?: number;
+  slack15?: number;
+  slack30?: number;
+  slack45?: number;
+  coverage?: number;
+  r0_i?: number;
+  xGH?: number;
+  DH?: number;
+  tGl?: number;
+  tGu?: number;
+  bins_count?: number;
+  num_flights?: number;
+};
+
+export type ProposalFlow = {
+  flow_id: number;
+  flight_ids: string[];
+  control_volume_id: string | null;
+  baseline_rate_per_hour: number;
+  allowed_rate_per_hour: number;
+  assigned_cut_per_hour: number;
+  time_window_label: string;
+  time_window_bins: number[];
+  features: ProposalFlowFeatures;
+  final_score: number;
+};
+
+export type ProposalObjectiveComponents = {
+  before: Record<string, number>;
+  after: Record<string, number>;
+  delta: Record<string, number>;
+};
+
+export type RegulationProposal = {
+  id: string;
+  hotspot: {
+    traffic_volume_id: string;
+    input_time_window: string;
+    timebins: number[];
+  };
+  control_window: {
+    bins: number[];
+    label: string;
+  };
+  objective_improvement: {
+    delta_deficit_per_hour: number;
+    delta_objective_score: number;
+  };
+  objective_components: ProposalObjectiveComponents;
+  flows: ProposalFlow[];
+  diagnostics?: Record<string, number>;
+};
+
+export type ProposeRegulationsResponse = {
+  traffic_volume_id: string;
+  time_window: string;
+  time_bin_minutes: number;
+  top_k: number;
+  weights: Record<string, number>;
+  num_proposals: number;
+  proposals: RegulationProposal[];
+};
+
+export function toTimeWindow(fromHHMM: string, toHHMM: string): string {
+  return `${fromHHMM}-${toHHMM}`;
+}
+
+export async function proposeRegulations(
+  body: ProposeRegulationsRequest
+): Promise<ProposeRegulationsResponse> {
+  const res = await authFetch("/propose_regulations", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const message = await res.text().catch(() => "Failed to propose regulations");
+    throw new Error(message || "Failed to propose regulations");
+  }
+  const data = await res.json();
+  const enriched = {
+    ...data,
+    proposals: (data?.proposals || []).map((p: any, i: number) => ({
+      ...p,
+      id: `RP-${String(i + 1).padStart(2, "0")} ${data?.traffic_volume_id ?? "TV"} ${String(data?.time_window ?? "").replaceAll(":", "")}`,
+    })),
+  };
+  return enriched as ProposeRegulationsResponse;
+}
+
+export function collectProposalFlights(proposal: RegulationProposal | null | undefined): Set<string> {
+  const flights = new Set<string>();
+  if (!proposal) return flights;
+  for (const flow of proposal.flows || []) {
+    for (const flight of flow.flight_ids || []) {
+      flights.add(String(flight));
+    }
+  }
+  return flights;
+}
+
+export function collectAllProposalFlights(
+  response: ProposeRegulationsResponse | null | undefined
+): Set<string> {
+  const flights = new Set<string>();
+  if (!response) return flights;
+  for (const proposal of response.proposals || []) {
+    const ids = collectProposalFlights(proposal);
+    ids.forEach((id) => flights.add(id));
+  }
+  return flights;
+}


### PR DESCRIPTION
## Summary
- add regulation proposal request/response helpers and feature collectors
- extend the sim store with proposal state, preview actions, and `/propose_regulations` fetching
- surface proposal fetching from the flow regulation panel and mount a detailed RegulationProposalPanel with preview controls
- prioritize proposal previews in FlowCanvas rendering and include the proposal panel on the flows page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68daec3275a0832bbe49c63c40d305ac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Regulation Proposal Panel with interactive proposal lists, per-proposal and per-flow metrics, expandable details, flight lists, preview toggles (per item and “Preview All”), re-run with Top K, loading skeletons, and clear error/no-results messaging.
  - Introduced a Propose action in the Regulation panel with validation (single traffic volume and valid time window) and inline error display.
  - Enabled proposal-based flight previews on the canvas, prioritizing proposal previews over other preview modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->