### PR TITLE
Add research preview label to header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -136,8 +136,11 @@ const [flightQueryInitialPrompt, setFlightQueryInitialPrompt] = useState('');
     <>
     <header className="absolute top-0 left-0 right-0 z-[2000] bg-gradient-to-b from-black to-transparent">
       <div className="flex items-center justify-between px-6 py-1">
-        <div className="flex items-center">
+        <div className="flex items-center space-x-3">
           <h1 className="text-xl font-bold text-white">Flow&apos;s Kitchen</h1>
+          <span className="text-[0.625rem] uppercase tracking-widest text-white/80 border border-white/60 rounded px-2 py-0.5">
+            RESEARCH PREVIEW
+          </span>
         </div>
         
         <div className="flex items-center space-x-8">


### PR DESCRIPTION
## Summary
- add a bordered "RESEARCH PREVIEW" label next to the Flow’s Kitchen heading in the header

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dd928e46a0832b9e32b3b010f0f454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “RESEARCH PREVIEW” badge in the header next to the app title.

* **Style**
  * Improved horizontal spacing in the header’s left section for clearer layout and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->