### PR TITLE
Adjust select dropdown spacing

### DIFF
--- a/src/app/original_count/page.tsx
+++ b/src/app/original_count/page.tsx
@@ -9,6 +9,7 @@ import { loadSectors } from "@/lib/airspace";
 import TimeScaleControl from "@/components/TimeScaleControl";
 import TrafficVolumeInfoTooltip from "@/components/TrafficVolumeInfoTooltip";
 import TrafficOverloadBar, { TrafficOverloadDatum } from "@/components/TrafficOverloadBar";
+import SelectChevron from "@/components/SelectChevron";
 import {
   ComposedChart,
   Bar,
@@ -258,14 +259,17 @@ export default function OriginalCountPage() {
               </div>
               <div>
                 <div className="text-[11px] opacity-80 mb-1 text-white">Rank by</div>
-                <select
-                  value={rankBy}
-                  onChange={(e) => setRankBy(e.currentTarget.value)}
-                  className="w-full px-3 py-2 bg-white/10 border border-white/20 rounded-lg focus:outline-none text-white"
-                >
-                  <option value="total_excess">Total Excess</option>
-                  <option value="total_count">Total Count</option>
-                </select>
+                <div className="relative">
+                  <select
+                    value={rankBy}
+                    onChange={(e) => setRankBy(e.currentTarget.value)}
+                    className="w-full appearance-none pl-3 pr-10 py-2 bg-white/10 border border-white/20 rounded-lg focus:outline-none text-white"
+                  >
+                    <option value="total_excess">Total Excess</option>
+                    <option value="total_count">Total Count</option>
+                  </select>
+                  <SelectChevron />
+                </div>
               </div>
             </div>
             <div className="mt-4 flex flex-wrap items-center gap-3">

--- a/src/components/PredictionSettingsPanel.tsx
+++ b/src/components/PredictionSettingsPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import SelectChevron from "@/components/SelectChevron";
 
 type PredictionSettingsPanelProps = {
   embedded?: boolean;
@@ -45,25 +46,31 @@ export default function PredictionSettingsPanel({
           <h2 className="font-semibold mb-3">Simulation Settings</h2>
           <div className="space-y-3">
             <FormField label="Behavioural Model">
-              <select
-                value={model}
-                onChange={(e) => setModel(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-transparent [&>option]:bg-slate-800 [&>option]:text-white"
-              >
-                <option value="Equinox Summer 2023">
-                  Equinox Summer 2023
-                </option>
-              </select>
+              <div className="relative">
+                <select
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  className="w-full appearance-none pl-3 pr-10 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-transparent [&>option]:bg-slate-800 [&>option]:text-white"
+                >
+                  <option value="Equinox Summer 2023">
+                    Equinox Summer 2023
+                  </option>
+                </select>
+                <SelectChevron />
+              </div>
             </FormField>
 
             <FormField label="Regulation Scenario">
-              <select
-                value={regulationScenario}
-                onChange={(e) => setRegulationScenario(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-transparent [&>option]:bg-slate-800 [&>option]:text-white"
-              >
-                <option value="Default">Default</option>
-              </select>
+              <div className="relative">
+                <select
+                  value={regulationScenario}
+                  onChange={(e) => setRegulationScenario(e.target.value)}
+                  className="w-full appearance-none pl-3 pr-10 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-transparent [&>option]:bg-slate-800 [&>option]:text-white"
+                >
+                  <option value="Default">Default</option>
+                </select>
+                <SelectChevron />
+              </div>
             </FormField>
           </div>
         </div>
@@ -103,17 +110,20 @@ export default function PredictionSettingsPanel({
               </FormField>
 
               <FormField label="Reporting value">
-                <select
-                  value={reportingValue}
-                  onChange={(e) => setReportingValue(e.target.value)}
-                  className="w-full px-3 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-transparent [&>option]:bg-slate-800 [&>option]:text-white"
-                >
-                  {reportingOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {option}
-                    </option>
-                  ))}
-                </select>
+                <div className="relative">
+                  <select
+                    value={reportingValue}
+                    onChange={(e) => setReportingValue(e.target.value)}
+                    className="w-full appearance-none pl-3 pr-10 py-2 rounded-lg bg-white/10 border border-white/20 text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-400/50 focus:border-transparent [&>option]:bg-slate-800 [&>option]:text-white"
+                  >
+                    {reportingOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                  <SelectChevron />
+                </div>
               </FormField>
             </div>
           </div>

--- a/src/components/SelectChevron.tsx
+++ b/src/components/SelectChevron.tsx
@@ -1,0 +1,18 @@
+export default function SelectChevron() {
+  return (
+    <div className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-white/70">
+      <svg
+        aria-hidden="true"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="w-4 h-4"
+      >
+        <path
+          fillRule="evenodd"
+          d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 10.184l3.71-2.954a.75.75 0 0 1 .94 1.168l-4.24 3.38a.75.75 0 0 1-.94 0l-4.24-3.38a.75.75 0 0 1 .02-1.06z"
+          clipRule="evenodd"
+        />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable SelectChevron helper to render consistent select dropdown icons
- update PredictionSettingsPanel selects to use the shared chevron and provide balanced padding
- fix the rank-by dropdown in original count view to match the updated spacing

## Testing
- npm run lint *(fails: pre-existing lint errors in other files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b31e4f40832bbcd3695dbe6b7f0f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced dropdown controls with a consistent chevron indicator across “Rank by” and Prediction Settings panels.
  - Improved usability and visual clarity for selection inputs without changing behavior or data handling.

- Style
  - Refined select styling with updated spacing and appearance for a cleaner, more modern look.
  - Better alignment and padding to accommodate the new chevron, improving readability and tap targets on all devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->